### PR TITLE
Add support for Graphite web exp() function

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -113,7 +113,6 @@ _When `format=png`_ (default if not specified)
 | aliasQuery |
 | averageOutsidePercentile |
 | events |
-| exp |
 | exponentialMovingAverage |
 | holtWintersConfidenceArea |
 | identity |
@@ -218,6 +217,7 @@ reverse: default value mismatch: got (empty), should be false |
 | divideSeriesLists(dividendSeriesList, divisorSeriesList) | no |
 | drawAsInfinite(seriesList) | no |
 | exclude(seriesList, pattern) | no |
+| exp(seriesList) | no |
 | fallbackSeries(seriesList, fallback) | no |
 | filterSeries(seriesList, func, operator, threshold) | no |
 | grep(seriesList, pattern) | no |

--- a/expr/functions/exp/function.go
+++ b/expr/functions/exp/function.go
@@ -38,8 +38,9 @@ func (f *exp) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 
 	for _, a := range args {
 		r := *a
-		r.Name = fmt.Sprintf("%s(%s)", e.Target(), a.Name)
+		r.Name = fmt.Sprintf("exp(%s)", a.Name)
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["exp"] = "e"
 
 		for i, v := range a.Values {
 			if math.IsNaN(v) {

--- a/expr/functions/exp/function.go
+++ b/expr/functions/exp/function.go
@@ -1,0 +1,74 @@
+package exp
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+)
+
+type exp struct {
+	interfaces.FunctionBase
+}
+
+// offset(seriesList,factor)
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &exp{}
+	for _, n := range []string{"exp"} {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+func (f *exp) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+	var results []*types.MetricData
+
+	for _, a := range args {
+		r := *a
+		r.Name = fmt.Sprintf("%s(%s)", e.Target(), a.Name)
+		r.Values = make([]float64, len(a.Values))
+
+		for i, v := range a.Values {
+			if math.IsNaN(v) {
+				r.Values[i] = math.NaN()
+			} else {
+				r.Values[i] = math.Exp(v)
+			}
+		}
+		results = append(results, &r)
+	}
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *exp) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"add": {
+			Description: "Raise e to the power of the datapoint, where e = 2.718281… is the base of natural logarithms.\n\nExample:\n\n.. code-block:: none\n\n  &target=exp(Server.instance01.threads.busy)",
+			Function:    "exp(seriesList)",
+			Group:       "Transform",
+			Module:      "graphite.render.functions",
+			Name:        "exp",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/exp/function_test.go
+++ b/expr/functions/exp/function_test.go
@@ -22,7 +22,7 @@ func init() {
 	}
 }
 
-func TestDelay(t *testing.T) {
+func TestExp(t *testing.T) {
 	now32 := int64(time.Now().Unix())
 
 	tests := []th.EvalTestItem{

--- a/expr/functions/exp/function_test.go
+++ b/expr/functions/exp/function_test.go
@@ -39,7 +39,7 @@ func TestDelay(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/exp/function_test.go
+++ b/expr/functions/exp/function_test.go
@@ -1,0 +1,46 @@
+package exp
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/metadata"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+	th "github.com/grafana/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestDelay(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"exp(metric1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 2, math.NaN(), 3, 4, 5, 6, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("exp(metric1)",
+				[]float64{2.718281828459, 2.718281828459, 7.3890560989307, math.NaN(), 20.085536923188, 54.598150033144, 148.41315910258, 403.42879349274, math.NaN()}, 1, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+		})
+	}
+
+}

--- a/expr/functions/exp/function_test.go
+++ b/expr/functions/exp/function_test.go
@@ -39,7 +39,7 @@ func TestDelay(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/divideSeries"
 	"github.com/grafana/carbonapi/expr/functions/ewma"
 	"github.com/grafana/carbonapi/expr/functions/exclude"
+	"github.com/grafana/carbonapi/expr/functions/exp"
 	"github.com/grafana/carbonapi/expr/functions/fallbackSeries"
 	"github.com/grafana/carbonapi/expr/functions/fft"
 	"github.com/grafana/carbonapi/expr/functions/filter"
@@ -137,6 +138,7 @@ func New(configs map[string]string) {
 		{name: "divideSeries", filename: "divideSeries", order: divideSeries.GetOrder(), f: divideSeries.New},
 		{name: "ewma", filename: "ewma", order: ewma.GetOrder(), f: ewma.New},
 		{name: "exclude", filename: "exclude", order: exclude.GetOrder(), f: exclude.New},
+		{name: "exp", filename: "exp", order: exp.GetOrder(), f: exp.New},
 		{name: "fallbackSeries", filename: "fallbackSeries", order: fallbackSeries.GetOrder(), f: fallbackSeries.New},
 		{name: "fft", filename: "fft", order: fft.GetOrder(), f: fft.New},
 		{name: "filter", filename: "filter", order: filter.GetOrder(), f: filter.New},


### PR DESCRIPTION
This PR adds support for the Graphite web exp() function, described as:

`exp(seriesList)
Raise e to the power of the datapoint, where e = 2.718281… is the base of natural logarithms.

Example:

&target=exp(Server.instance01.threads.busy)
`

 It also adds a test to verify the function works as expected.