### PR TITLE
Add support for Graphite web's aliasQuery() function

### DIFF
--- a/expr/functions/aliasQuery/function.go
+++ b/expr/functions/aliasQuery/function.go
@@ -1,0 +1,123 @@
+package aliasQuery
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+
+	"regexp"
+)
+
+type aliasQuery struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &aliasQuery{}
+	for _, n := range []string{"aliasQuery"} {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+func (f *aliasQuery) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	search, err := e.GetStringArg(1)
+	if err != nil {
+		return nil, err
+	}
+
+	replace, err := e.GetStringArg(2)
+	if err != nil {
+		return nil, err
+	}
+
+	newName, err := e.GetStringArg(3)
+	if err != nil {
+		return nil, err
+	}
+
+	re, err := regexp.Compile(search)
+	if err != nil {
+		return nil, err
+	}
+
+	replace = helper.Backref.ReplaceAllString(replace, "$${$1}")
+
+	var results []*types.MetricData
+
+	for _, a := range args {
+		metric := helper.ExtractMetric(a.Name)
+
+		r := *a
+		r.Name = re.ReplaceAllString(metric, replace)
+		r.Name = re.ReplaceAllString(newName, r.Name)
+		// Get the last value in the series and substitute it into the new name
+		r.Name = fmt.Sprintf(r.Name, getLastValue(a.Values))
+		results = append(results, &r)
+	}
+
+	return results, nil
+}
+
+func getLastValue(v []float64) float64 {
+	if len(v) > 0 {
+		i := len(v)
+		for i != 0 {
+			i--
+			if !math.IsNaN(v[i]) {
+				return v[i]
+			}
+		}
+	}
+	return math.NaN()
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *aliasQuery) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"aliasQuery": {
+			Description: "Performs a query to alias the metrics in seriesList.\n\n.. code-block:: none\n\n  &target=aliasQuery(channel.power.*,\"channel\\.power\\.([0-9]+)\",\"channel.frequency.\\1\", \"Channel %d MHz\")",
+			Function:    "aliasQuery(seriesList, search, replace, newName)",
+			Group:       "Alias",
+			Module:      "graphite.render.functions",
+			Name:        "aliasQuery",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "search",
+					Required: true,
+					Type:     types.String,
+				},
+				{
+					Name:     "replace",
+					Required: true,
+					Type:     types.String,
+				},
+				{
+					Name:     "newName",
+					Required: true,
+					Type:     types.String,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/aliasQuery/function_test.go
+++ b/expr/functions/aliasQuery/function_test.go
@@ -1,0 +1,56 @@
+package aliasQuery
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestAliasByNode(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"aliasQuery(chan.pow.1,'chan\\.pow\\.([0-9]+)','chan.freq.\\1',\"Channel %g MHz\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"chan.pow.1", 0, 1}: {types.MakeMetricData("chan.pow.1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("Channel 5 MHz",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			"aliasQuery(chan.pow.1,'chan\\.pow\\.([0-9]+)','chan.freq.\\1',\"Channel %g MHz\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"chan.pow.1", 0, 1}: {types.MakeMetricData("chan.pow.1", []float64{1, 2, 3, 4, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("Channel 4 MHz", []float64{1, 2, 3, 4, math.NaN()}, 1, now32),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-graphite/carbonapi/expr/functions/aliasByNode"
 	"github.com/go-graphite/carbonapi/expr/functions/aliasByPostgres"
 	"github.com/go-graphite/carbonapi/expr/functions/aliasByRedis"
+	"github.com/go-graphite/carbonapi/expr/functions/aliasQuery"
 	"github.com/go-graphite/carbonapi/expr/functions/aliasSub"
 	"github.com/go-graphite/carbonapi/expr/functions/asPercent"
 	"github.com/go-graphite/carbonapi/expr/functions/averageSeriesWithWildcards"
@@ -121,6 +122,7 @@ func New(configs map[string]string) {
 		{name: "aliasByNode", filename: "aliasByNode", order: aliasByNode.GetOrder(), f: aliasByNode.New},
 		{name: "aliasByPostgres", filename: "aliasByPostgres", order: aliasByPostgres.GetOrder(), f: aliasByPostgres.New},
 		{name: "aliasByRedis", filename: "aliasByRedis", order: aliasByRedis.GetOrder(), f: aliasByRedis.New},
+		{name: "aliasQuery", filename: "aliasQuery", order: aliasQuery.GetOrder(), f: aliasQuery.New},
 		{name: "aliasSub", filename: "aliasSub", order: aliasSub.GetOrder(), f: aliasSub.New},
 		{name: "asPercent", filename: "asPercent", order: asPercent.GetOrder(), f: asPercent.New},
 		{name: "averageSeriesWithWildcards", filename: "averageSeriesWithWildcards", order: averageSeriesWithWildcards.GetOrder(), f: averageSeriesWithWildcards.New},


### PR DESCRIPTION
This PR adds support for Graphite web's aliasQuery() function.

The aliasQuery() function is defined as:

```
aliasQuery(seriesList, search, replace, newName)
Performs a query to alias the metrics in seriesList.

&target=aliasQuery(channel.power.*,"channel\.power\.([0-9]+)","channel.frequency.\1", "Channel %d MHz")
The series in seriesList will be aliased by first translating the series names using the search & replace parameters, then using the last value of the resulting series to construct the alias using sprintf-style syntax.
```