### PR TITLE
Add support for xFilesFactor and setXFilesFactor

### DIFF
--- a/expr/functions/aggregate/function.go
+++ b/expr/functions/aggregate/function.go
@@ -40,6 +40,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 // aggregate(*seriesLists)
 func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	var args []*types.MetricData
+	var xFilesFactor float64
 	isAggregateFunc := true
 
 	callback, err := e.GetStringArg(1)
@@ -53,20 +54,21 @@ func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			}
 			callback = strings.Replace(e.Target(), "Series", "", 1)
 			isAggregateFunc = false
+			xFilesFactor = -1 // xFilesFactor is not used by the ...Series functions
 		}
 	} else {
 		args, err = helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 		if err != nil {
 			return nil, err
 		}
+		if len(e.Args()) == 3 {
+			xFilesFactor, err = e.GetFloatArgDefault(2, float64(args[0].XFilesFactor)) // If set by setXFilesFactor, all series in a list will have the same value
+
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
-
-	// TODO: Implement xFilesFactor
-
-	//xFilesFactor, err := e.GetFloatArgDefault(2, 0)
-	//if err != nil {
-	//	return nil, err
-	//}
 
 	aggFunc, ok := consolidations.ConsolidationToFunc[callback]
 	if !ok {
@@ -79,7 +81,7 @@ func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		e.SetRawArgs(e.Args()[0].Target())
 	}
 
-	results, err := helper.AggregateSeries(e, args, aggFunc)
+	results, err := helper.AggregateSeries(e, args, aggFunc, xFilesFactor)
 	if err != nil {
 		return nil, err
 	}
@@ -114,12 +116,12 @@ func (f *aggregate) Description() map[string]types.FunctionDescription {
 					Required: true,
 					Options:  types.StringsToSuggestionList(consolidations.AvailableConsolidationFuncs()),
 				},
-				/*
-					{
-						Name: "xFilesFactor",
-						Type: types.Float,
-					},
-				*/
+				{
+
+					Name:     "xFilesFactor",
+					Type:     types.Float,
+					Required: false,
+				},
 			},
 		},
 		"averageSeries": {

--- a/expr/functions/aggregate/function.go
+++ b/expr/functions/aggregate/function.go
@@ -62,12 +62,12 @@ func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	}
 
 	// TODO: Implement xFilesFactor
-	/*
-		xFilesFactor, err := e.GetFloatArgDefault(2, 0)
-		if err != nil {
-			return false, nil, err
-		}
-	*/
+
+	//xFilesFactor, err := e.GetFloatArgDefault(2, 0)
+	//if err != nil {
+	//	return nil, err
+	//}
+
 	aggFunc, ok := consolidations.ConsolidationToFunc[callback]
 	if !ok {
 		return nil, fmt.Errorf("unsupported consolidation function %s", callback)

--- a/expr/functions/aggregateWithWildcards/function.go
+++ b/expr/functions/aggregateWithWildcards/function.go
@@ -89,7 +89,7 @@ func (f *aggregateWithWildcards) Do(ctx context.Context, e parser.Expr, from, un
 	results := make([]*types.MetricData, 0, len(groups))
 
 	for _, node := range nodeList {
-		res, err := helper.AggregateSeries(e, groups[node], aggFunc)
+		res, err := helper.AggregateSeries(e, groups[node], aggFunc, -1) // Pass in -1 for xFilesFactor because aggregateWithWildcards doesn't support xFilesFactor
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -86,6 +86,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/scaleToSeconds"
 	"github.com/grafana/carbonapi/expr/functions/seriesByTag"
 	"github.com/grafana/carbonapi/expr/functions/seriesList"
+	"github.com/grafana/carbonapi/expr/functions/setXFilesFactor"
 	"github.com/grafana/carbonapi/expr/functions/sigmoid"
 	"github.com/grafana/carbonapi/expr/functions/sinFunction"
 	"github.com/grafana/carbonapi/expr/functions/slo"
@@ -201,6 +202,7 @@ func New(configs map[string]string) {
 		{name: "scaleToSeconds", filename: "scaleToSeconds", order: scaleToSeconds.GetOrder(), f: scaleToSeconds.New},
 		{name: "seriesByTag", filename: "seriesByTag", order: seriesByTag.GetOrder(), f: seriesByTag.New},
 		{name: "seriesList", filename: "seriesList", order: seriesList.GetOrder(), f: seriesList.New},
+		{name: "setXFilesFactor", filename: "setXFilesFactor", order: setXFilesFactor.GetOrder(), f: setXFilesFactor.New},
 		{name: "sigmoid", filename: "sigmoid", order: sigmoid.GetOrder(), f: sigmoid.New},
 		{name: "sinFunction", filename: "sinFunction", order: sinFunction.GetOrder(), f: sinFunction.New},
 		{name: "slo", filename: "slo", order: slo.GetOrder(), f: slo.New},

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -111,16 +111,12 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		return nil, err
 	}
 
-	fmt.Println("length of args: ", len(e.Args()))
 	if len(e.Args()) == 3 {
-		xFilesFactor, err = e.GetFloatArgDefault(2, 0)
-		fmt.Println("xfilesfactor: ", xFilesFactor)
+		xFilesFactor, err = e.GetFloatArgDefault(2, float64(arg[0].XFilesFactor))
 
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		xFilesFactor = float64(arg[0].XFilesFactor) // If set by setXFilesFactor, all series in a list will have the same value
 	}
 
 	var result []*types.MetricData
@@ -157,9 +153,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		w := &types.Windowed{Data: make([]float64, windowSize)}
 		for i, v := range a.Values {
 			if ridx := i - offset; ridx >= 0 {
-				fmt.Println("Window contains: ", w.Data)
 				if helper.XFilesFactorValues(w.Data, xFilesFactor) {
-					fmt.Println("values are good for xfilesfactor ", xFilesFactor)
 					switch e.Target() {
 					case "movingAverage":
 						r.Values[ridx] = w.Mean()
@@ -176,7 +170,6 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 						r.Values[ridx] = math.NaN()
 					}
 				} else {
-					fmt.Println("Xfilesfactor failed")
 					r.Values[ridx] = math.NaN()
 				}
 			}

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -88,7 +88,7 @@ func TestMovingXFilesFactor(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, math.NaN(), 2, math.NaN(), 3}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingSum(metric1,"3sec")`, []float64{2, 2, 2}, 1, 0)}, // StartTime = from
+			[]*types.MetricData{types.MakeMetricData(`movingSum(metric1,"3sec")`, []float64{6, 6, 4, 3, math.NaN()}, 1, 0)}, // StartTime = from
 		},
 		{
 			"movingAverage(metric1,4,0.6)",

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -78,3 +78,31 @@ func TestMoving(t *testing.T) {
 	}
 
 }
+
+func TestMovingXFilesFactor(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"movingSum(metric1,'3sec',0.5)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, math.NaN(), 2, math.NaN(), 3}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingSum(metric1,"3sec")`, []float64{2, 2, 2}, 1, 0)}, // StartTime = from
+		},
+		{
+			"movingAverage(metric1,4,0.6)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("movingAverage(metric1,4)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1.25, 1.5, 1.75, 2.5, 3.5, 4, 5}, 1, 0)}, // StartTime = from
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}

--- a/expr/functions/percentileOfSeries/function.go
+++ b/expr/functions/percentileOfSeries/function.go
@@ -46,9 +46,11 @@ func (f *percentileOfSeries) Do(ctx context.Context, e parser.Expr, from, until 
 		return nil, err
 	}
 
+	xFilesFactor := args[0].XFilesFactor
+
 	return helper.AggregateSeries(e, args, func(values []float64) float64 {
 		return consolidations.Percentile(values, percent, interpolate)
-	})
+	}, float64(xFilesFactor))
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/functions/removeEmptySeries/function.go
+++ b/expr/functions/removeEmptySeries/function.go
@@ -31,20 +31,25 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // removeEmptySeries(seriesLists, n), removeZeroSeries(seriesLists, n)
 func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	var xFilesFactor float64
 	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
 		return nil, err
 	}
 
-	factor, err := e.GetFloatArgDefault(1, 0)
-	if err != nil {
-		return nil, err
+	if len(e.Args()) == 2 {
+		xFilesFactor, err = e.GetFloatArgDefault(1, 0)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		xFilesFactor = float64(args[0].XFilesFactor) // If set by setXFilesFactor, all series in a list will have the same value
 	}
 
 	var results []*types.MetricData
 
 	for _, arg := range args {
-		nonNull := 0.0
+		nonNull := 0
 		for _, v := range arg.Values {
 			if !math.IsNaN(v) {
 				switch e.Target() {
@@ -57,7 +62,8 @@ func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until i
 				}
 			}
 		}
-		if nonNull != 0 && nonNull/float64(len(arg.Values)) >= factor {
+
+		if nonNull != 0 && helper.XFilesFactor(nonNull, len(arg.Values), xFilesFactor) {
 			r := arg.CopyLink()
 			r.Tags[e.Target()] = fmt.Sprintf("%f", factor)
 			results = append(results, r)

--- a/expr/functions/removeEmptySeries/function.go
+++ b/expr/functions/removeEmptySeries/function.go
@@ -38,12 +38,10 @@ func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until i
 	}
 
 	if len(e.Args()) == 2 {
-		xFilesFactor, err = e.GetFloatArgDefault(1, 0)
+		xFilesFactor, err = e.GetFloatArgDefault(1, float64(args[0].XFilesFactor)) // If set by setXFilesFactor, all series in a list will have the same value
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		xFilesFactor = float64(args[0].XFilesFactor) // If set by setXFilesFactor, all series in a list will have the same value
 	}
 
 	var results []*types.MetricData
@@ -65,7 +63,7 @@ func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until i
 
 		if nonNull != 0 && helper.XFilesFactor(nonNull, len(arg.Values), xFilesFactor) {
 			r := arg.CopyLink()
-			r.Tags[e.Target()] = fmt.Sprintf("%f", factor)
+			r.Tags[e.Target()] = fmt.Sprintf("%f", xFilesFactor)
 			results = append(results, r)
 		}
 	}

--- a/expr/functions/setXFilesFactor/function.go
+++ b/expr/functions/setXFilesFactor/function.go
@@ -1,0 +1,71 @@
+package setXFilesFactor
+
+import (
+	"context"
+
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+)
+
+type setXFilesFactor struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(_ string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &setXFilesFactor{}
+	functions := []string{"setXFilesFactor", "xFilesFactor"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// setXFilesFactor(seriesList, xFilesFactor)
+func (f *setXFilesFactor) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	xFilesFactor, err := e.GetFloatArg(1)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, a := range args {
+		a.XFilesFactor = float32(xFilesFactor)
+	}
+	return args, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *setXFilesFactor) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"setXFilesFactor": {
+			Description: "Takes one metric or a wildcard seriesList and an xFilesFactor value between 0 and 1. When a series needs to be consolidated, this sets the fraction of values in an interval that must\nnot be null for the consolidation to be considered valid. If there are not enough values then None will be returned for that interval.\n\nExample:\n\n.. code-block:: none\n\n  &target=xFilesFactor(Sales.widgets.largeBlue, 0.5)\n  &target=Servers.web01.sda1.free_space|consolidateBy('max')|xFilesFactor(0.5)",
+			Function:    "setXFilesFactor(seriesList, xFilesFactor)",
+			Group:       "Transform",
+			Module:      "graphite.render.functions",
+			Name:        "setXFilesFactor",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "xFilesFactor",
+					Required: false,
+					Type:     types.Float,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/weightedAverage/function.go
+++ b/expr/functions/weightedAverage/function.go
@@ -48,6 +48,7 @@ func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int
 	alignedMetrics := helper.AlignSeries(append(avgs, weights...))
 	avgs = alignedMetrics[0:len(avgs)]
 	weights = alignedMetrics[len(avgs):]
+	xFilesFactor := float64(alignedMetrics[0].XFilesFactor)
 
 	nodes, err := e.GetNodeOrTagArgs(2)
 	if err != nil {
@@ -94,7 +95,7 @@ func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int
 		if _, ok := pair["weight"]; !ok {
 			continue
 		}
-		product, err := helper.AggregateSeries(e, []*types.MetricData{pair["avg"], pair["weight"]}, consolidations.ConsolidationToFunc["multiply"])
+		product, err := helper.AggregateSeries(e, []*types.MetricData{pair["avg"], pair["weight"]}, consolidations.ConsolidationToFunc["multiply"], xFilesFactor)
 		if err != nil {
 			return nil, err
 		}
@@ -104,15 +105,15 @@ func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int
 		return []*types.MetricData{}, nil
 	}
 
-	sumProducts, err := helper.AggregateSeries(e, productList, consolidations.AggSum)
+	sumProducts, err := helper.AggregateSeries(e, productList, consolidations.AggSum, xFilesFactor)
 	if err != nil {
 		return nil, err
 	}
-	sumWeights, err := helper.AggregateSeries(e, weights, consolidations.AggSum)
+	sumWeights, err := helper.AggregateSeries(e, weights, consolidations.AggSum, xFilesFactor)
 	if err != nil {
 		return nil, err
 	}
-	weightedAverageSeries, err := helper.AggregateSeries(e, append(sumProducts, sumWeights...), func(v []float64) float64 { return v[0] / v[1] })
+	weightedAverageSeries, err := helper.AggregateSeries(e, append(sumProducts, sumWeights...), func(v []float64) float64 { return v[0] / v[1] }, xFilesFactor)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -336,7 +336,7 @@ func XFilesFactorValues(values []float64, xFilesFactor float64) bool {
 }
 
 func XFilesFactor(nonNull int, total int, xFilesFactor float64) bool {
-	if nonNull <= 0 || total <= 0 {
+	if nonNull < 0 || total <= 0 {
 		return false
 	}
 	return float64(nonNull)/float64(total) >= xFilesFactor

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -145,7 +145,12 @@ type AggregateFunc func([]float64) float64
 
 // AggregateSeries aggregates series
 func AggregateSeries(e parser.Expr, args []*types.MetricData, function AggregateFunc, xFilesFactor float64) ([]*types.MetricData, error) {
+	var applyXFilesFactor = true
 	args = AlignSeries(args)
+
+	if xFilesFactor < 0 {
+		applyXFilesFactor = true
+	}
 
 	needScale := false
 	for i := 1; i < len(args); i++ {
@@ -179,7 +184,9 @@ func AggregateSeries(e parser.Expr, args []*types.MetricData, function Aggregate
 
 		r.Values[i] = math.NaN()
 		if len(values) > 0 {
-			if XFilesFactorValues(values, xFilesFactor) {
+			if applyXFilesFactor && XFilesFactorValues(values, xFilesFactor) {
+				r.Values[i] = function(values)
+			} else {
 				r.Values[i] = function(values)
 			}
 		}


### PR DESCRIPTION
This PR adds support for xFilesFactor and setXFilesFactor.

The SetXFilesFactor function is defined as:

```
setXFilesFactor(seriesList, xFilesFactor)
Short form: xFilesFactor()

Takes one metric or a wildcard seriesList and an xFilesFactor value between 0 and 1

When a series needs to be consolidated, this sets the fraction of values in an interval that must not be null for the consolidation to be considered valid. If there are not enough values then None will be returned for that interval.

&target=xFilesFactor(Sales.widgets.largeBlue, 0.5)
&target=Servers.web01.sda1.free_space|consolidateBy('max')|xFilesFactor(0.5)
The xFilesFactor set via this function is used as the default for all functions that accept an xFilesFactor parameter, all functions that aggregate data across multiple series and/or intervals, and [maxDataPoints](https://graphite.readthedocs.io/en/latest/render_api.html#maxdatapoints) consolidation.

A default for the entire render request can also be set using the [xFilesFactor](https://graphite.readthedocs.io/en/latest/render_api.html#xfilesfactor) query parameter.

Note

xFilesFactor follows the same semantics as in Whisper storage schemas. Setting it to 0 (the default) means that only a single value in a given interval needs to be non-null, setting it to 1 means that all values in the interval must be non-null. A setting of 0.5 means that at least half the values in the interval must be non-null.
```