### PR TITLE
Add support for Graphite web unique() function

### DIFF
--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -99,6 +99,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/timeStack"
 	"github.com/grafana/carbonapi/expr/functions/transformNull"
 	"github.com/grafana/carbonapi/expr/functions/tukey"
+	"github.com/grafana/carbonapi/expr/functions/unique"
 	"github.com/grafana/carbonapi/expr/functions/weightedAverage"
 	"github.com/grafana/carbonapi/expr/interfaces"
 	"github.com/grafana/carbonapi/expr/metadata"
@@ -208,6 +209,7 @@ func New(configs map[string]string) {
 		{name: "timeStack", filename: "timeStack", order: timeStack.GetOrder(), f: timeStack.New},
 		{name: "transformNull", filename: "transformNull", order: transformNull.GetOrder(), f: transformNull.New},
 		{name: "tukey", filename: "tukey", order: tukey.GetOrder(), f: tukey.New},
+		{name: "unique", filename: "unique", order: unique.GetOrder(), f: unique.New},
 		{name: "weightedAverage", filename: "weightedAverage", order: weightedAverage.GetOrder(), f: weightedAverage.New},
 	}
 

--- a/expr/functions/unique/function.go
+++ b/expr/functions/unique/function.go
@@ -27,7 +27,7 @@ func New(_ string) []interfaces.FunctionMetadata {
 	return res
 }
 
-// round(seriesList,precision)
+// unique(seriesList)
 func (f *unique) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {

--- a/expr/functions/unique/function.go
+++ b/expr/functions/unique/function.go
@@ -3,10 +3,10 @@ package unique
 import (
 	"context"
 
-	"github.com/go-graphite/carbonapi/expr/helper"
-	"github.com/go-graphite/carbonapi/expr/interfaces"
-	"github.com/go-graphite/carbonapi/expr/types"
-	"github.com/go-graphite/carbonapi/pkg/parser"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
 )
 
 type unique struct {

--- a/expr/functions/unique/function.go
+++ b/expr/functions/unique/function.go
@@ -1,0 +1,67 @@
+package unique
+
+import (
+	"context"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+)
+
+type unique struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(_ string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &unique{}
+	functions := []string{"unique"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// round(seriesList,precision)
+func (f *unique) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*types.MetricData
+	seenNames := make(map[string]bool)
+
+	for _, a := range arg {
+		if _, ok := seenNames[a.Name]; !ok {
+			seenNames[a.Name] = true
+			results = append(results, a)
+		}
+	}
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *unique) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"unique": {
+			Description: "Takes an arbitrary number of seriesLists and returns unique series, filtered by name.\n\nExample:\n\n.. code-block:: none\n\n  &target=unique(mostDeviant(server.*.disk_free,5),lowestCurrent(server.*.disk_free,5))\n\n  Draws servers with low disk space, and servers with highly deviant disk space, but never the same series twice.",
+			Function:    "unique(seriesList)",
+			Group:       "Transform",
+			Module:      "graphite.render.functions",
+			Name:        "unique",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/unique/function_test.go
+++ b/expr/functions/unique/function_test.go
@@ -1,0 +1,53 @@
+package unique
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestUnique(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			`unique(metric[1234])`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[1234]", 0, 1}: {
+					types.MakeMetricData("metric1.foo.bar.baz", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2.foo.bar.baz", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric3.foo.bar.baz", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+					types.MakeMetricData("metric1.foo.bar.baz", []float64{4, math.NaN(), 5, 6, 7, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1.foo.bar.baz", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+				types.MakeMetricData("metric2.foo.bar.baz", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+				types.MakeMetricData("metric3.foo.bar.baz", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}

--- a/expr/functions/unique/function_test.go
+++ b/expr/functions/unique/function_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-graphite/carbonapi/expr/helper"
-	"github.com/go-graphite/carbonapi/expr/metadata"
-	"github.com/go-graphite/carbonapi/expr/types"
-	"github.com/go-graphite/carbonapi/pkg/parser"
-	th "github.com/go-graphite/carbonapi/tests"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/metadata"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+	th "github.com/grafana/carbonapi/tests"
 )
 
 func init() {


### PR DESCRIPTION
This PR adds support for Graphite web's unique() function.

The unique() function defined as:

```
unique(*seriesLists)
Takes an arbitrary number of seriesLists and returns unique series, filtered by name.

Example:

&target=unique(mostDeviant(server.*.disk_free,5),lowestCurrent(server.*.disk_free,5))
Draws servers with low disk space, and servers with highly deviant disk space, but never the same series twice.
```