### PR TITLE
Add support for Graphite web sigmoid() function

### DIFF
--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -86,6 +86,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/scaleToSeconds"
 	"github.com/grafana/carbonapi/expr/functions/seriesByTag"
 	"github.com/grafana/carbonapi/expr/functions/seriesList"
+	"github.com/grafana/carbonapi/expr/functions/sigmoid"
 	"github.com/grafana/carbonapi/expr/functions/sinFunction"
 	"github.com/grafana/carbonapi/expr/functions/slo"
 	"github.com/grafana/carbonapi/expr/functions/smartSummarize"

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -200,6 +200,7 @@ func New(configs map[string]string) {
 		{name: "scaleToSeconds", filename: "scaleToSeconds", order: scaleToSeconds.GetOrder(), f: scaleToSeconds.New},
 		{name: "seriesByTag", filename: "seriesByTag", order: seriesByTag.GetOrder(), f: seriesByTag.New},
 		{name: "seriesList", filename: "seriesList", order: seriesList.GetOrder(), f: seriesList.New},
+		{name: "sigmoid", filename: "sigmoid", order: sigmoid.GetOrder(), f: sigmoid.New},
 		{name: "sinFunction", filename: "sinFunction", order: sinFunction.GetOrder(), f: sinFunction.New},
 		{name: "slo", filename: "slo", order: slo.GetOrder(), f: slo.New},
 		{name: "smartSummarize", filename: "smartSummarize", order: smartSummarize.GetOrder(), f: smartSummarize.New},

--- a/expr/functions/sigmoid/function.go
+++ b/expr/functions/sigmoid/function.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/go-graphite/carbonapi/expr/helper"
-	"github.com/go-graphite/carbonapi/expr/interfaces"
-	"github.com/go-graphite/carbonapi/expr/types"
-	"github.com/go-graphite/carbonapi/pkg/parser"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
 )
 
 type sigmoid struct {

--- a/expr/functions/sigmoid/function.go
+++ b/expr/functions/sigmoid/function.go
@@ -29,7 +29,7 @@ func New(_ string) []interfaces.FunctionMetadata {
 	return res
 }
 
-// round(seriesList,precision)
+// sigmoid(seriesList)
 func (f *sigmoid) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
@@ -41,9 +41,10 @@ func (f *sigmoid) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 		r := *a
 		r.Name = fmt.Sprintf("sigmoid(%s)", a.Name)
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["sigmoid"] = "sigmoid"
 
 		for i, v := range a.Values {
-			if math.IsNaN(v) {
+			if math.IsNaN(v) || math.Exp(-v) == -1 { // check for -1 result as this would cause a divide by zero error
 				r.Values[i] = math.NaN()
 			} else {
 				r.Values[i] = (1 / (1 + math.Exp(-v)))

--- a/expr/functions/sigmoid/function.go
+++ b/expr/functions/sigmoid/function.go
@@ -38,7 +38,7 @@ func (f *sigmoid) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 	var results []*types.MetricData
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("sigmoid(%s)", a.Name)
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["sigmoid"] = "sigmoid"
@@ -50,7 +50,7 @@ func (f *sigmoid) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 				r.Values[i] = (1 / (1 + math.Exp(-v)))
 			}
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/sigmoid/function.go
+++ b/expr/functions/sigmoid/function.go
@@ -1,0 +1,75 @@
+package sigmoid
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+)
+
+type sigmoid struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(_ string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &sigmoid{}
+	functions := []string{"sigmoid"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// round(seriesList,precision)
+func (f *sigmoid) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+	var results []*types.MetricData
+
+	for _, a := range arg {
+		r := *a
+		r.Name = fmt.Sprintf("sigmoid(%s)", a.Name)
+		r.Values = make([]float64, len(a.Values))
+
+		for i, v := range a.Values {
+			if math.IsNaN(v) {
+				r.Values[i] = math.NaN()
+			} else {
+				r.Values[i] = (1 / (1 + math.Exp(-v)))
+			}
+		}
+		results = append(results, &r)
+	}
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *sigmoid) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"sigmoid": {
+			Description: "Takes one metric or a wildcard seriesList and applies the sigmoid function 1 / (1 + exp(-x)) to each datapoint.\n\nExample:\n\n.. code-block:: none\n\n  &target=sigmoid(Server.instance01.threads.busy)\n  &target=sigmoid(Server.instance*.threads.busy)",
+			Function:    "sigmoid(seriesList)",
+			Group:       "Transform",
+			Module:      "graphite.render.functions",
+			Name:        "sigmoid",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/sigmoid/function_test.go
+++ b/expr/functions/sigmoid/function_test.go
@@ -1,0 +1,45 @@
+package sigmoid
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestFunction(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"sigmoid(metric1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{5, 1, math.NaN(), 0, 12, 125, 10.4, 1.1}, 60, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("sigmoid(metric1)", []float64{0.9933071490757153, 0.7310585786300049, math.NaN(), 0.5, 0.9999938558253978, 1, 0.9999695684430994, 0.7502601055951177}, 60, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}

--- a/expr/functions/sigmoid/function_test.go
+++ b/expr/functions/sigmoid/function_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-graphite/carbonapi/expr/helper"
-	"github.com/go-graphite/carbonapi/expr/metadata"
-	"github.com/go-graphite/carbonapi/expr/types"
-	"github.com/go-graphite/carbonapi/pkg/parser"
-	th "github.com/go-graphite/carbonapi/tests"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/metadata"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+	th "github.com/grafana/carbonapi/tests"
 )
 
 func init() {


### PR DESCRIPTION
This PR adds support for the Graphite web sigmoid() function.

The sigmoid function is defined as:

```
sigmoid(seriesList)
Takes one metric or a wildcard seriesList and applies the sigmoid function 1 / (1 + exp(-x)) to each datapoint.

Example:

&target=sigmoid(Server.instance01.threads.busy)
&target=sigmoid(Server.instance*.threads.busy)
```