### PR TITLE
Add support for Graphite web exponentialMovingAverage function

### DIFF
--- a/expr/functions/exponentialMovingAverage/function.go
+++ b/expr/functions/exponentialMovingAverage/function.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/go-graphite/carbonapi/expr/helper"
-	"github.com/go-graphite/carbonapi/expr/interfaces"
-	"github.com/go-graphite/carbonapi/expr/types"
-	"github.com/go-graphite/carbonapi/pkg/parser"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
 )
 
 type exponentialMovingAverage struct {

--- a/expr/functions/exponentialMovingAverage/function.go
+++ b/expr/functions/exponentialMovingAverage/function.go
@@ -67,7 +67,6 @@ func New(configFile string) []interfaces.FunctionMetadata {
 func (f *exponentialMovingAverage) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	var n int
 	var err error
-	var constant float64
 	var scaleByStep bool
 
 	var argstr string
@@ -120,8 +119,6 @@ func (f *exponentialMovingAverage) Do(ctx context.Context, e parser.Expr, from, 
 		offset = windowSize
 	}
 
-	constant = float64(2 / (float64(windowSize) + 1))
-
 	for _, a := range arg {
 		r := a.CopyLink()
 		r.Name = fmt.Sprintf("%s(%s,%s)", e.Target(), a.Name, argstr)
@@ -141,7 +138,7 @@ func (f *exponentialMovingAverage) Do(ctx context.Context, e parser.Expr, from, 
 		r.StartTime = (from + r.StepTime - 1) / r.StepTime * r.StepTime // align StartTime to closest >= StepTime
 		r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime
 
-		w := types.NewExpMovingAverage(windowSize, float64(constant))
+		w := types.NewExpMovingAverage(windowSize)
 		for i, v := range a.Values {
 			if ridx := i - offset; ridx >= 0 {
 				if math.IsNaN(v) {

--- a/expr/functions/exponentialMovingAverage/function.go
+++ b/expr/functions/exponentialMovingAverage/function.go
@@ -1,0 +1,96 @@
+package exponentialMovingAverage
+
+import (
+	"context"
+	"math"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+)
+
+type exponentialMovingAverage struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &exponentialMovingAverage{}
+	functions := []string{"exponentialMovingAverage"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+func (f *exponentialMovingAverage) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	windowSize, err := e.GetFloatArg(1)
+	if err != nil {
+		return nil, err
+	}
+
+	e.SetTarget("ema")
+
+	// ugh, helper.ForEachSeriesDo does not handle arguments properly
+	var results []*types.MetricData
+
+	var constant = 2 / (windowSize + 1)
+	for _, a := range arg {
+		r := *a
+
+		r.Values = make([]float64, len(a.Values))
+
+		w := types.NewExpMovingAverage(constant)
+
+		for i, v := range a.Values {
+			if math.IsNaN(v) {
+				r.Values[i] = math.NaN()
+				continue
+			}
+
+			w.Push(v)
+			r.Values[i] = w.Mean()
+		}
+		results = append(results, &r)
+	}
+	return results, nil
+}
+
+func (f *exponentialMovingAverage) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"exponentialMovingAverage": {
+			Description: "Takes a series of values and a window size and produces an exponential moving average utilizing the following formula:\n\n ema(current) = constant * (Current Value) + (1 - constant) * ema(previous)\n The Constant is calculated as:\n constant = 2 / (windowSize + 1) \n The first period EMA uses a simple moving average for its value.\n Example:\n\n code-block:: none\n\n  &target=exponentialMovingAverage(*.transactions.count, 10) \n\n &target=exponentialMovingAverage(*.transactions.count, '-10s')",
+			Function:    "exponentialWeightedMovingAverage(seriesList, alpha)",
+			Group:       "Calculate",
+			Module:      "graphite.render.functions.custom",
+			Name:        "exponentialWeightedMovingAverage",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "alpha",
+					Required: true,
+					Suggestions: types.NewSuggestions(
+						0.1,
+						0.5,
+						0.7,
+					),
+					Type: types.Float,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/exponentialMovingAverage/function.go
+++ b/expr/functions/exponentialMovingAverage/function.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
+
+	"github.com/lomik/zapwriter"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
 
 	"github.com/grafana/carbonapi/expr/helper"
 	"github.com/grafana/carbonapi/expr/interfaces"
@@ -13,59 +18,146 @@ import (
 
 type exponentialMovingAverage struct {
 	interfaces.FunctionBase
+
+	config movingConfig
 }
 
 func GetOrder() interfaces.Order {
 	return interfaces.Any
 }
 
+type movingConfig struct {
+	ReturnNaNsIfStepMismatch *bool
+}
+
 func New(configFile string) []interfaces.FunctionMetadata {
+	logger := zapwriter.Logger("functionInit").With(zap.String("function", "moving"))
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &exponentialMovingAverage{}
 	functions := []string{"exponentialMovingAverage"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
+	cfg := movingConfig{}
+	v := viper.New()
+	v.SetConfigFile(configFile)
+	err := v.ReadInConfig()
+	if err != nil {
+		logger.Info("failed to read config file, using default",
+			zap.Error(err),
+		)
+	} else {
+		err = v.Unmarshal(&cfg)
+		if err != nil {
+			logger.Fatal("failed to parse config",
+				zap.Error(err),
+			)
+			return nil
+		}
+		f.config = cfg
+	}
+
+	if cfg.ReturnNaNsIfStepMismatch == nil {
+		v := true
+		f.config.ReturnNaNsIfStepMismatch = &v
+	}
 	return res
 }
 
 func (f *exponentialMovingAverage) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	var n int
+	var err error
+	var constant float64
+	var scaleByStep bool
+
+	var argstr string
+
+	if len(e.Args()) < 2 {
+		return nil, parser.ErrMissingArgument
+	}
+
+	switch e.Args()[1].Type() {
+	case parser.EtConst:
+		// In this case, zipper does not request additional retrospective points,
+		// and leading `n` values, that used to calculate window, become NaN
+		n, err = e.GetIntArg(1)
+		argstr = strconv.Itoa(n)
+	case parser.EtString:
+		var n32 int32
+		n32, err = e.GetIntervalArg(1, 1)
+		argstr = fmt.Sprintf("%q", e.Args()[1].StringValue())
+		n = int(n32)
+		scaleByStep = true
+	default:
+		err = parser.ErrBadType
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	windowSize, err := e.GetFloatArg(1)
+	windowSize := n
+
+	start := from
+	if scaleByStep {
+		start -= int64(n)
+	}
+
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], start, until, values)
 	if err != nil {
 		return nil, err
 	}
 
-	e.SetTarget("exponentialMovingAverage")
-
-	// ugh, helper.ForEachSeriesDo does not handle arguments properly
 	var results []*types.MetricData
 
-	var constant = 2 / (windowSize + 1)
+	if len(arg) == 0 {
+		return results, nil
+	}
+
+	var offset int
+
+	if scaleByStep {
+		windowSize /= int(arg[0].StepTime)
+		offset = windowSize
+	}
+
+	constant = float64(2 / (float64(windowSize) + 1))
+
 	for _, a := range arg {
-		name := fmt.Sprintf("exponentialMovingAverage(%s,%v)", a.Name, windowSize)
-		r := *a
+		r := a.CopyLink()
+		r.Name = fmt.Sprintf("%s(%s,%s)", e.Target(), a.Name, argstr)
 
-		r := *a
-		r.Name = name
-		r.Values = make([]float64, len(a.Values))
-
-		w := types.NewExpMovingAverage(constant)
-
-		for i, v := range a.Values {
-			if math.IsNaN(v) {
-				r.Values[i] = math.NaN()
-				continue
+		if windowSize == 0 {
+			if *f.config.ReturnNaNsIfStepMismatch {
+				r.Values = make([]float64, len(a.Values))
+				for i := range a.Values {
+					r.Values[i] = math.NaN()
+				}
 			}
-
-			w.Push(v)
-			r.Values[i] = w.Mean()
+			results = append(results, r)
+			continue
 		}
-		results = append(results, &r)
+
+		r.Values = make([]float64, len(a.Values))
+		r.StartTime = (from + r.StepTime - 1) / r.StepTime * r.StepTime // align StartTime to closest >= StepTime
+		r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime
+
+		w := types.NewExpMovingAverage(windowSize, float64(constant))
+		for i, v := range a.Values {
+			if ridx := i - offset; ridx >= 0 {
+				if math.IsNaN(v) {
+					r.Values[i] = math.NaN()
+					continue
+				}
+
+				r.Values[i] = w.Mean()
+
+				if i < windowSize || math.IsNaN(r.Values[ridx]) {
+					r.Values[ridx] = math.NaN()
+				}
+			}
+			w.Push(v)
+		}
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/exponentialMovingAverage/function_test.go
+++ b/expr/functions/exponentialMovingAverage/function_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-graphite/carbonapi/expr/helper"
-	"github.com/go-graphite/carbonapi/expr/metadata"
-	"github.com/go-graphite/carbonapi/expr/types"
-	"github.com/go-graphite/carbonapi/pkg/parser"
-	th "github.com/go-graphite/carbonapi/tests"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/metadata"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+	th "github.com/grafana/carbonapi/tests"
 )
 
 func init() {

--- a/expr/functions/exponentialMovingAverage/function_test.go
+++ b/expr/functions/exponentialMovingAverage/function_test.go
@@ -1,0 +1,47 @@
+package exponentialMovingAverage
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestEMA(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"exponentialMovingAverage(metric1,2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 1, 1, 1, math.NaN(), 1, 1}, 1, now32)},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("exponentialMovingAverage(metric1,2)", []float64{0, 0.6666666666666666, 0.8888888888888888, 0.962962962962963, math.NaN(), 0.9876543209876543, 0.9958847736625513}, 1, now32),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}

--- a/expr/functions/exponentialMovingAverage/function_test.go
+++ b/expr/functions/exponentialMovingAverage/function_test.go
@@ -1,9 +1,7 @@
 package exponentialMovingAverage
 
 import (
-	"math"
 	"testing"
-	"time"
 
 	"github.com/grafana/carbonapi/expr/helper"
 	"github.com/grafana/carbonapi/expr/metadata"
@@ -22,17 +20,17 @@ func init() {
 	}
 }
 
-func TestEMA(t *testing.T) {
-	now32 := int64(time.Now().Unix())
+func TestExponentialMovingAverage(t *testing.T) {
+	startTime := int64(0)
 
 	tests := []th.EvalTestItem{
 		{
 			"exponentialMovingAverage(metric1,3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 1, 1, math.NaN(), 1, 1}, 1, now32)},
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, 1, startTime)},
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("exponentialMovingAverage(metric1,3)", []float64{math.NaN(), math.NaN(), math.NaN(), 1.1875, math.NaN(), 1.046875, 1.01171875}, 1, 0),
+				types.MakeMetricData("exponentialMovingAverage(metric1,3)", []float64{4, 6, 9, 11.5, 13.75, 15.875, 17.9375}, 1, 0),
 			},
 		},
 	}

--- a/expr/functions/exponentialMovingAverage/function_test.go
+++ b/expr/functions/exponentialMovingAverage/function_test.go
@@ -27,12 +27,12 @@ func TestEMA(t *testing.T) {
 
 	tests := []th.EvalTestItem{
 		{
-			"exponentialMovingAverage(metric1,2)",
+			"exponentialMovingAverage(metric1,3)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 1, 1, 1, math.NaN(), 1, 1}, 1, now32)},
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 1, 1, math.NaN(), 1, 1}, 1, now32)},
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("exponentialMovingAverage(metric1,2)", []float64{0, 0.6666666666666666, 0.8888888888888888, 0.962962962962963, math.NaN(), 0.9876543209876543, 0.9958847736625513}, 1, now32),
+				types.MakeMetricData("exponentialMovingAverage(metric1,3)", []float64{math.NaN(), math.NaN(), math.NaN(), 1.1875, math.NaN(), 1.046875, 1.01171875}, 1, 0),
 			},
 		},
 	}

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -1,7 +1,6 @@
 package functions
 
 import (
-	"github.com/grafana/carbonapi/expr/functions/powSeries"
 	"sort"
 	"strings"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/ewma"
 	"github.com/grafana/carbonapi/expr/functions/exclude"
 	"github.com/grafana/carbonapi/expr/functions/exp"
+	"github.com/grafana/carbonapi/expr/functions/exponentialMovingAverage"
 	"github.com/grafana/carbonapi/expr/functions/fallbackSeries"
 	"github.com/grafana/carbonapi/expr/functions/fft"
 	"github.com/grafana/carbonapi/expr/functions/filter"
@@ -79,6 +79,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/percentileOfSeries"
 	"github.com/grafana/carbonapi/expr/functions/polyfit"
 	"github.com/grafana/carbonapi/expr/functions/pow"
+	"github.com/grafana/carbonapi/expr/functions/powSeries"
 	"github.com/grafana/carbonapi/expr/functions/randomWalk"
 	"github.com/grafana/carbonapi/expr/functions/rangeOfSeries"
 	"github.com/grafana/carbonapi/expr/functions/reduce"
@@ -152,6 +153,7 @@ func New(configs map[string]string) {
 		{name: "ewma", filename: "ewma", order: ewma.GetOrder(), f: ewma.New},
 		{name: "exclude", filename: "exclude", order: exclude.GetOrder(), f: exclude.New},
 		{name: "exp", filename: "exp", order: exp.GetOrder(), f: exp.New},
+		{name: "exponentialMovingAverage", filename: "exponentialMovingAverage", order: exponentialMovingAverage.GetOrder(), f: exponentialMovingAverage.New},
 		{name: "fallbackSeries", filename: "fallbackSeries", order: fallbackSeries.GetOrder(), f: fallbackSeries.New},
 		{name: "fft", filename: "fft", order: fft.GetOrder(), f: fft.New},
 		{name: "filter", filename: "filter", order: filter.GetOrder(), f: filter.New},

--- a/expr/functions/round/function.go
+++ b/expr/functions/round/function.go
@@ -3,7 +3,6 @@ package round
 import (
 	"context"
 	"fmt"
-	"math"
 
 	"github.com/grafana/carbonapi/expr/helper"
 	"github.com/grafana/carbonapi/expr/interfaces"
@@ -52,20 +51,12 @@ func (f *round) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		r.Values = make([]float64, len(a.Values))
 
 		for i, v := range a.Values {
-			r.Values[i] = doRound(v, precision)
+			r.Values[i] = helper.SafeRound(v, precision)
 		}
 		r.Tags["round"] = fmt.Sprintf("%d", precision)
 		results = append(results, r)
 	}
 	return results, nil
-}
-
-func doRound(x float64, precision int) float64 {
-	if math.IsNaN(x) {
-		return x
-	}
-	roundTo := math.Pow10(precision)
-	return math.RoundToEven(x*roundTo) / roundTo
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -281,6 +281,34 @@ func GetCommonTags(series []*types.MetricData) map[string]string {
 	return commonTags
 }
 
+func SafeRound(x float64, precision int) float64 {
+	if math.IsNaN(x) {
+		return x
+	}
+	roundTo := math.Pow10(precision)
+	return math.RoundToEven(x*roundTo) / roundTo
+}
+
+func XFilesFactorValues(values []float64, xFilesFactor float64) bool {
+	if math.IsNaN(xFilesFactor) || xFilesFactor == 0 {
+		return true
+	}
+	nonNull := 0
+	for _, val := range values {
+		if !math.IsNaN(val) {
+			nonNull++
+		}
+	}
+	return XFilesFactor(nonNull, len(values), xFilesFactor)
+}
+
+func XFilesFactor(nonNull int, total int, xFilesFactor float64) bool {
+	if nonNull < 0 || total <= 0 {
+		return false
+	}
+	return float64(nonNull)/float64(total) >= xFilesFactor
+}
+
 type unitPrefix struct {
 	prefix string
 	size   uint64
@@ -327,24 +355,4 @@ func FormatUnits(v float64, system string) (float64, string) {
 		v = math.Floor(v)
 	}
 	return v, ""
-}
-
-func XFilesFactorValues(values []float64, xFilesFactor float64) bool {
-	if math.IsNaN(xFilesFactor) || xFilesFactor == 0 {
-		return true
-	}
-	nonNull := 0
-	for _, val := range values {
-		if !math.IsNaN(val) {
-			nonNull++
-		}
-	}
-	return XFilesFactor(nonNull, len(values), xFilesFactor)
-}
-
-func XFilesFactor(nonNull int, total int, xFilesFactor float64) bool {
-	if nonNull < 0 || total <= 0 {
-		return false
-	}
-	return float64(nonNull)/float64(total) >= xFilesFactor
 }

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -21,6 +21,12 @@ type Windowed struct {
 	nans   int
 }
 
+type ExpWindowed struct {
+	n        int
+	ema      float64
+	constant float64
+}
+
 // Push pushes data
 func (w *Windowed) Push(n float64) {
 	if len(w.Data) == 0 {

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -21,16 +21,6 @@ type Windowed struct {
 	nans   int
 }
 
-type ExpWindowed struct {
-	Data     []float64
-	head     int
-	length   int
-	n        int
-	ema      float64
-	constant float64
-	nans     int
-}
-
 // Push pushes data
 func (w *Windowed) Push(n float64) {
 	if len(w.Data) == 0 {
@@ -116,59 +106,4 @@ func (w *Windowed) Min() float64 {
 		}
 	}
 	return rv
-}
-
-func NewExpMovingAverage(windowSize int) *ExpWindowed {
-	constant := float64(2 / (float64(windowSize) + 1))
-	return &ExpWindowed{Data: make([]float64, windowSize), constant: constant}
-}
-
-// Push pushes data
-func (w *ExpWindowed) Push(x float64) {
-	if len(w.Data) == 0 {
-		return
-	}
-	old := w.Data[w.head]
-
-	w.length++
-
-	w.Data[w.head] = x
-	w.head++
-	if w.head >= len(w.Data) {
-		w.head = 0
-	}
-
-	if !math.IsNaN(old) {
-		if w.n == 0 {
-			w.ema = x
-		} else {
-			w.ema = w.constant*x + (1-w.constant)*w.ema
-		}
-	} else {
-		w.nans--
-	}
-
-	if !math.IsNaN(x) {
-		if w.n == 0 {
-			w.ema = x
-		} else {
-			w.ema = w.constant*x + (1-w.constant)*w.ema
-
-		}
-	} else {
-		w.nans++
-	}
-	w.n++
-}
-
-func (w *ExpWindowed) Mean() float64 {
-	return w.ema
-}
-
-func (w *ExpWindowed) Len() int {
-	if w.length < len(w.Data) {
-		return w.length - w.nans
-	}
-
-	return len(w.Data) - w.nans
 }

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -13,24 +13,22 @@ import (
 
 // Windowed is a struct to compute simple windowed stats
 type Windowed struct {
-	Data      []float64
-	head      int
-	length    int
-	sum       float64
-	sumsq     float64
-	nans      int
-	processed int
+	Data   []float64
+	head   int
+	length int
+	sum    float64
+	sumsq  float64
+	nans   int
 }
 
 type ExpWindowed struct {
-	Data      []float64
-	head      int
-	length    int
-	n         int
-	ema       float64
-	constant  float64
-	nans      int
-	processed int
+	Data     []float64
+	head     int
+	length   int
+	n        int
+	ema      float64
+	constant float64
+	nans     int
 }
 
 // Push pushes data
@@ -62,7 +60,6 @@ func (w *Windowed) Push(n float64) {
 	} else {
 		w.nans++
 	}
-	w.processed++
 }
 
 // Len returns current len of data
@@ -121,7 +118,8 @@ func (w *Windowed) Min() float64 {
 	return rv
 }
 
-func NewExpMovingAverage(windowSize int, constant float64) *ExpWindowed {
+func NewExpMovingAverage(windowSize int) *ExpWindowed {
+	constant := float64(2 / (float64(windowSize) + 1))
 	return &ExpWindowed{Data: make([]float64, windowSize), constant: constant}
 }
 
@@ -161,7 +159,6 @@ func (w *ExpWindowed) Push(x float64) {
 		w.nans++
 	}
 	w.n++
-	w.processed++
 }
 
 func (w *ExpWindowed) Mean() float64 {

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -107,3 +107,24 @@ func (w *Windowed) Min() float64 {
 	}
 	return rv
 }
+
+func NewExpMovingAverage(constant float64) *ExpWindowed {
+	return &ExpWindowed{constant: constant}
+}
+
+func (w *ExpWindowed) Push(x float64) {
+	if w.n == 0 {
+		w.ema = x
+	} else {
+		w.ema = w.constant*x + (1-w.constant)*w.ema
+	}
+	w.n++
+}
+
+func (w *ExpWindowed) Mean() float64 {
+	return w.ema
+}
+
+func (e *ExpWindowed) Len() int {
+	return e.n
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -185,7 +185,7 @@ func (e *expr) Metrics() []MetricRequest {
 			for i := range r {
 				r[i].From -= 7 * 86400 // starts -7 days from where the original starts
 			}
-		case "movingAverage", "movingMedian", "movingMin", "movingMax", "movingSum":
+		case "movingAverage", "movingMedian", "movingMin", "movingMax", "movingSum", "exponentialMovingAverage":
 			if len(e.args) < 2 {
 				return nil
 			}


### PR DESCRIPTION
This PR adds support for the Graphite web exponentialMovingAverage() function.

The exponentialMovingAverage function is defined as:

```
exponentialMovingAverage(seriesList, windowSize)
Takes a series of values and a window size and produces an exponential moving average utilizing the following formula:

ema(current) = constant * (Current Value) + (1 - constant) * ema(previous)
The Constant is calculated as:

constant = 2 / (windowSize + 1)
The first period EMA uses a simple moving average for its value.

Example:

&target=exponentialMovingAverage(*.transactions.count, 10)
&target=exponentialMovingAverage(*.transactions.count, '-10s')
```

The Graphite web implementation can be found [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L1373).