### PR TITLE
Add support for Graphite web minMax() function

### DIFF
--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/absolute"
 	"github.com/grafana/carbonapi/expr/functions/aggregate"
 	"github.com/grafana/carbonapi/expr/functions/aggregateLine"
-	"github.com/grafana/carbonapi/expr/functions/aggregateSeriesLists"
 	"github.com/grafana/carbonapi/expr/functions/alias"
 	"github.com/grafana/carbonapi/expr/functions/aliasByBase64"
 	"github.com/grafana/carbonapi/expr/functions/aliasByMetric"
@@ -120,7 +119,6 @@ func New(configs map[string]string) {
 		{name: "absolute", filename: "absolute", order: absolute.GetOrder(), f: absolute.New},
 		{name: "aggregate", filename: "aggregate", order: aggregate.GetOrder(), f: aggregate.New},
 		{name: "aggregateLine", filename: "aggregateLine", order: aggregateLine.GetOrder(), f: aggregateLine.New},
-		{name: "aggregateSeriesLists", filename: "aggregateSeriesLists", order: aggregateSeriesLists.GetOrder(), f: aggregateSeriesLists.New},
 		{name: "alias", filename: "alias", order: alias.GetOrder(), f: alias.New},
 		{name: "aliasByBase64", filename: "aliasByBase64", order: aliasByBase64.GetOrder(), f: aliasByBase64.New},
 		{name: "aliasByMetric", filename: "aliasByMetric", order: aliasByMetric.GetOrder(), f: aliasByMetric.New},

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -171,6 +171,7 @@ func New(configs map[string]string) {
 		{name: "logit", filename: "logit", order: logit.GetOrder(), f: logit.New},
 		{name: "lowPass", filename: "lowPass", order: lowPass.GetOrder(), f: lowPass.New},
 		{name: "mapSeries", filename: "mapSeries", order: mapSeries.GetOrder(), f: mapSeries.New},
+		{name: "minMax", filename: "minMax", order: minMax.GetOrder(), f: minMax.New},
 		{name: "mostDeviant", filename: "mostDeviant", order: mostDeviant.GetOrder(), f: mostDeviant.New},
 		{name: "moving", filename: "moving", order: moving.GetOrder(), f: moving.New},
 		{name: "movingMedian", filename: "movingMedian", order: movingMedian.GetOrder(), f: movingMedian.New},

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/absolute"
 	"github.com/grafana/carbonapi/expr/functions/aggregate"
 	"github.com/grafana/carbonapi/expr/functions/aggregateLine"
+	"github.com/grafana/carbonapi/expr/functions/aggregateSeriesLists"
 	"github.com/grafana/carbonapi/expr/functions/alias"
 	"github.com/grafana/carbonapi/expr/functions/aliasByBase64"
 	"github.com/grafana/carbonapi/expr/functions/aliasByMetric"
@@ -60,6 +61,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/logit"
 	"github.com/grafana/carbonapi/expr/functions/lowPass"
 	"github.com/grafana/carbonapi/expr/functions/mapSeries"
+	"github.com/grafana/carbonapi/expr/functions/minMax"
 	"github.com/grafana/carbonapi/expr/functions/mostDeviant"
 	"github.com/grafana/carbonapi/expr/functions/moving"
 	"github.com/grafana/carbonapi/expr/functions/movingMedian"
@@ -118,6 +120,7 @@ func New(configs map[string]string) {
 		{name: "absolute", filename: "absolute", order: absolute.GetOrder(), f: absolute.New},
 		{name: "aggregate", filename: "aggregate", order: aggregate.GetOrder(), f: aggregate.New},
 		{name: "aggregateLine", filename: "aggregateLine", order: aggregateLine.GetOrder(), f: aggregateLine.New},
+		{name: "aggregateSeriesLists", filename: "aggregateSeriesLists", order: aggregateSeriesLists.GetOrder(), f: aggregateSeriesLists.New},
 		{name: "alias", filename: "alias", order: alias.GetOrder(), f: alias.New},
 		{name: "aliasByBase64", filename: "aliasByBase64", order: aliasByBase64.GetOrder(), f: aliasByBase64.New},
 		{name: "aliasByMetric", filename: "aliasByMetric", order: aliasByMetric.GetOrder(), f: aliasByMetric.New},

--- a/expr/functions/minMax/function.go
+++ b/expr/functions/minMax/function.go
@@ -1,0 +1,81 @@
+package minMax
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/go-graphite/carbonapi/expr/consolidations"
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+)
+
+type minMax struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &minMax{}
+	functions := []string{"minMax"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// highestAverage(seriesList, n) , highestCurrent(seriesList, n), highestMax(seriesList, n)
+func (f *minMax) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*types.MetricData
+
+	for _, a := range arg {
+		r := *a
+		r.Name = fmt.Sprintf("minMax(%s)", a.Name)
+		r.Values = make([]float64, len(a.Values))
+
+		min := consolidations.MinValue(a.Values)
+		max := consolidations.MaxValue(a.Values)
+
+		for i, v := range a.Values {
+			if !math.IsNaN(v) {
+				r.Values[i] = (v - min) / (max - min)
+			} else {
+				r.Values[i] = math.NaN()
+			}
+		}
+		results = append(results, &r)
+	}
+
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *minMax) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"minMax": {
+			Description: "Applies the popular min max normalization technique, which takes each point and applies the following normalization transformation to it: normalized = (point - min) / (max - min).\n\nExample:\n\n.. code-block:: none\n\n  &target=minMax(Server.instance01.threads.busy)",
+			Function:    "minMax(seriesList)",
+			Group:       "Transform",
+			Module:      "graphite.render.functions",
+			Name:        "minMax",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/minMax/function.go
+++ b/expr/functions/minMax/function.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/go-graphite/carbonapi/expr/consolidations"
-	"github.com/go-graphite/carbonapi/expr/helper"
-	"github.com/go-graphite/carbonapi/expr/interfaces"
-	"github.com/go-graphite/carbonapi/expr/types"
-	"github.com/go-graphite/carbonapi/pkg/parser"
+	"github.com/grafana/carbonapi/expr/consolidations"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
 )
 
 type minMax struct {
@@ -45,11 +45,21 @@ func (f *minMax) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		r.Values = make([]float64, len(a.Values))
 
 		min := consolidations.MinValue(a.Values)
+		if math.IsInf(min, -1) {
+			min = 0.0
+		}
 		max := consolidations.MaxValue(a.Values)
+		if math.IsInf(max, 1) {
+			max = 0.0
+		}
 
 		for i, v := range a.Values {
 			if !math.IsNaN(v) {
-				r.Values[i] = (v - min) / (max - min)
+				if max != min {
+					r.Values[i] = (v - min) / (max - min)
+				} else {
+					r.Values[i] = 0.0
+				}
 			} else {
 				r.Values[i] = math.NaN()
 			}

--- a/expr/functions/minMax/function.go
+++ b/expr/functions/minMax/function.go
@@ -45,11 +45,11 @@ func (f *minMax) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		r.Values = make([]float64, len(a.Values))
 
 		min := consolidations.MinValue(a.Values)
-		if math.IsInf(min, -1) {
+		if math.IsInf(min, 1) {
 			min = 0.0
 		}
 		max := consolidations.MaxValue(a.Values)
-		if math.IsInf(max, 1) {
+		if math.IsInf(max, -1) {
 			max = 0.0
 		}
 

--- a/expr/functions/minMax/function_test.go
+++ b/expr/functions/minMax/function_test.go
@@ -1,0 +1,46 @@
+package minMax
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestFunction(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"minMax(metric1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{10, 20, 30, math.NaN(), 40, 50}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("minMax(metric1)",
+				[]float64{0.0, 0.25, 0.50, math.NaN(), 0.75, 1.0}, 1, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}

--- a/expr/functions/minMax/function_test.go
+++ b/expr/functions/minMax/function_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-graphite/carbonapi/expr/helper"
-	"github.com/go-graphite/carbonapi/expr/metadata"
-	"github.com/go-graphite/carbonapi/expr/types"
-	"github.com/go-graphite/carbonapi/pkg/parser"
-	th "github.com/go-graphite/carbonapi/tests"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/metadata"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+	th "github.com/grafana/carbonapi/tests"
 )
 
 func init() {
@@ -33,6 +33,14 @@ func TestFunction(t *testing.T) {
 			},
 			[]*types.MetricData{types.MakeMetricData("minMax(metric1)",
 				[]float64{0.0, 0.25, 0.50, math.NaN(), 0.75, 1.0}, 1, now32)},
+		},
+		{
+			"minMax(metric1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{10, 10, 10, math.NaN(), 10, 10}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("minMax(metric1)",
+				[]float64{0, 0, 0, math.NaN(), 0, 0}, 1, now32)},
 		},
 	}
 


### PR DESCRIPTION
This PR adds support for Graphite web's minMax() function.

The minMax function is defined as:

```
minMax(seriesList)
Applies the popular min max normalization technique, which takes each point and applies the following normalization transformation to it: normalized = (point - min) / (max - min).

Example:

&target=minMax(Server.instance01.threads.busy)
```

The Graphite web implementation of minMax() can be found [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L5875)