### PR TITLE
Update go.mod with new path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-graphite/carbonapi
+module github.com/grafana/carbonapi
 
 go 1.14
 


### PR DESCRIPTION
This PR updates the module declaration in the go.mod file. This is necessary for properly importing this fork of CarbonAPI.