### PR TITLE
Update tags handling in expr functions to match Graphite web

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -281,7 +281,7 @@ func TestEvalExpression(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 }

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -281,7 +281,11 @@ func TestEvalExpression(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 }

--- a/expr/functions/absolute/function.go
+++ b/expr/functions/absolute/function.go
@@ -36,6 +36,7 @@ func (f *absolute) Do(ctx context.Context, e parser.Expr, from, until int64, val
 			}
 			r.Values[i] = math.Abs(v)
 		}
+		r.Tags["absolute"] = "1"
 		return r
 	})
 }

--- a/expr/functions/absolute/function_test.go
+++ b/expr/functions/absolute/function_test.go
@@ -38,7 +38,11 @@ func TestAbsolute(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/absolute/function_test.go
+++ b/expr/functions/absolute/function_test.go
@@ -38,7 +38,7 @@ func TestAbsolute(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/aggregate/function.go
+++ b/expr/functions/aggregate/function.go
@@ -78,7 +78,12 @@ func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	if isAggregateFunc {
 		e.SetRawArgs(e.Args()[0].Target())
 	}
-	return helper.AggregateSeries(e, args, aggFunc)
+
+	results := helper.AggregateSeries(e, args, aggFunc)
+
+	results.Tags["aggregatedBy"] = callback
+
+	return results
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/functions/aggregate/function.go
+++ b/expr/functions/aggregate/function.go
@@ -79,11 +79,16 @@ func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		e.SetRawArgs(e.Args()[0].Target())
 	}
 
-	results := helper.AggregateSeries(e, args, aggFunc)
+	results, err := helper.AggregateSeries(e, args, aggFunc)
+	if err != nil {
+		return nil, err
+	}
 
-	results.Tags["aggregatedBy"] = callback
+	for _, result := range results {
+		result.Tags["aggregatedBy"] = callback
+	}
 
-	return results
+	return results, nil
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -272,7 +272,7 @@ func TestAverageSeries(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -272,7 +272,11 @@ func TestAverageSeries(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/aliasByNode/function_test.go
+++ b/expr/functions/aliasByNode/function_test.go
@@ -113,7 +113,11 @@ func TestAliasByNode(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/aliasByNode/function_test.go
+++ b/expr/functions/aliasByNode/function_test.go
@@ -113,7 +113,7 @@ func TestAliasByNode(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -33,15 +33,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // asPercent(seriesList, total=None, *nodes)
 func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	fmt.Println("in asPercent. exp: ", e)
 	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
-	fmt.Println("in asPercent. arg: ", arg)
-
-	fmt.Println("Values: ")
-	for i, v := range values {
-		fmt.Println("req: ", i)
-		fmt.Println("Val: ", v)
-	}
 
 	if err != nil {
 		return nil, err
@@ -59,11 +51,6 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 
 	var results []*types.MetricData
 
-	fmt.Println("length of args: ", len(e.Args()))
-	fmt.Println("ARgs are: ")
-	for _, a := range e.Args() {
-		fmt.Println("Arg: ", a)
-	}
 	if len(e.Args()) == 1 {
 		arg = helper.AlignSeries(types.CopyMetricDataSlice(arg))
 		getTotal = func(i int) float64 {
@@ -87,7 +74,6 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		}
 	} else if len(e.Args()) == 2 && e.Args()[1].IsConst() {
 		total, err := e.GetFloatArg(1)
-		fmt.Println("total: ", total)
 
 		if err != nil {
 			return nil, err
@@ -100,8 +86,6 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		}
 	} else if len(e.Args()) == 2 && (e.Args()[1].IsName() || e.Args()[1].IsFunc()) {
 		total, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
-		fmt.Println("total: ", len(total))
-		fmt.Println("series: ", total)
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -33,7 +33,16 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // asPercent(seriesList, total=None, *nodes)
 func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	fmt.Println("in asPercent. exp: ", e)
 	arg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	fmt.Println("in asPercent. arg: ", arg)
+
+	fmt.Println("Values: ")
+	for i, v := range values {
+		fmt.Println("req: ", i)
+		fmt.Println("Val: ", v)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -50,6 +59,11 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 
 	var results []*types.MetricData
 
+	fmt.Println("length of args: ", len(e.Args()))
+	fmt.Println("ARgs are: ")
+	for _, a := range e.Args() {
+		fmt.Println("Arg: ", a)
+	}
 	if len(e.Args()) == 1 {
 		arg = helper.AlignSeries(types.CopyMetricDataSlice(arg))
 		getTotal = func(i int) float64 {
@@ -73,6 +87,8 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		}
 	} else if len(e.Args()) == 2 && e.Args()[1].IsConst() {
 		total, err := e.GetFloatArg(1)
+		fmt.Println("total: ", total)
+
 		if err != nil {
 			return nil, err
 		}
@@ -84,6 +100,8 @@ func (f *asPercent) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		}
 	} else if len(e.Args()) == 2 && (e.Args()[1].IsName() || e.Args()[1].IsFunc()) {
 		total, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
+		fmt.Println("total: ", len(total))
+		fmt.Println("series: ", total)
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -149,7 +149,7 @@ func TestAliasByNode(t *testing.T) {
 	for _, tt := range testAlignments {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 }

--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -149,7 +149,11 @@ func TestAliasByNode(t *testing.T) {
 	for _, tt := range testAlignments {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 }

--- a/expr/functions/cairo/cairo_test.go
+++ b/expr/functions/cairo/cairo_test.go
@@ -73,6 +73,6 @@ func TestEvalExpressionGraph(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		th.TestEvalExpr(t, &tt)
+		th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 	}
 }

--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -712,6 +712,7 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 			r := *a
 			r.Stacked = true
 			r.StackName = stackName
+			r.Tags["stacked"] = stackName
 			results = append(results, &r)
 		}
 
@@ -791,10 +792,13 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 					return nil, err
 				}
 				r.Dashed = d
+				r.Tags["dashed"] = fmt.Sprintf("%f", d)
 			case "drawAsInfinite":
 				r.DrawAsInfinite = true
+				r.Tags["drawAsInfinite"] = "1"
 			case "secondYAxis":
 				r.SecondYAxis = true
+				r.Tags["secondYAxis"] = "1"
 			}
 
 			results = append(results, &r)

--- a/expr/functions/consolidateBy/function.go
+++ b/expr/functions/consolidateBy/function.go
@@ -45,7 +45,7 @@ func (f *consolidateBy) Do(ctx context.Context, e parser.Expr, from, until int64
 		r := *a
 
 		r.AggregateFunction = consolidations.ConsolidationToFunc[name]
-
+		r.Tags["consolidateBy"] = name
 		results = append(results, &r)
 	}
 

--- a/expr/functions/delay/function.go
+++ b/expr/functions/delay/function.go
@@ -65,6 +65,7 @@ func (f *delay) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		result := *series
 		result.Name = fmt.Sprintf("delay(%s,%d)", series.Name, steps)
 		result.Values = newValues
+		result.Tags["delay"] = string(steps)
 
 		results = append(results, &result)
 	}

--- a/expr/functions/delay/function.go
+++ b/expr/functions/delay/function.go
@@ -65,7 +65,7 @@ func (f *delay) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		result := *series
 		result.Name = fmt.Sprintf("delay(%s,%d)", series.Name, steps)
 		result.Values = newValues
-		result.Tags["delay"] = string(steps)
+		result.Tags["delay"] = fmt.Sprintf("%d", steps)
 
 		results = append(results, &result)
 	}

--- a/expr/functions/delay/function_test.go
+++ b/expr/functions/delay/function_test.go
@@ -39,7 +39,11 @@ func TestDelay(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/delay/function_test.go
+++ b/expr/functions/delay/function_test.go
@@ -39,7 +39,7 @@ func TestDelay(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/derivative/function.go
+++ b/expr/functions/derivative/function.go
@@ -40,6 +40,7 @@ func (f *derivative) Do(ctx context.Context, e parser.Expr, from, until int64, v
 				prev = v
 			}
 		}
+		r.Tags["derivative"] = "1"
 		return r
 	})
 }

--- a/expr/functions/derivative/function_test.go
+++ b/expr/functions/derivative/function_test.go
@@ -47,7 +47,11 @@ func TestDerivative(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/derivative/function_test.go
+++ b/expr/functions/derivative/function_test.go
@@ -47,7 +47,7 @@ func TestDerivative(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/exp/function_test.go
+++ b/expr/functions/exp/function_test.go
@@ -39,7 +39,11 @@ func TestExp(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/hitcount/function.go
+++ b/expr/functions/hitcount/function.go
@@ -43,10 +43,6 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 		return nil, err
 	}
 	bucketSize := int64(bucketSizeInt32)
-	intervalString, err := e.GetStringArg(1)
-	if err != nil {
-		return nil, err
-	}
 
 	alignToInterval, err := e.GetBoolNamedOrPosArgDefault("alignToInterval", 2, false)
 	if err != nil {
@@ -84,7 +80,7 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 			},
 			Tags: arg.Tags,
 		}
-		r.Tags["hitcount"] = intervalString
+		r.Tags["hitcount"] = fmt.Sprintf("%d", bucketSizeInt32)
 
 		bucketEnd := start + bucketSize
 		t := arg.StartTime

--- a/expr/functions/hitcount/function.go
+++ b/expr/functions/hitcount/function.go
@@ -43,6 +43,10 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 		return nil, err
 	}
 	bucketSize := int64(bucketSizeInt32)
+	intervalString, err := e.GetStringArg(1)
+	if err != nil {
+		return nil, err
+	}
 
 	alignToInterval, err := e.GetBoolNamedOrPosArgDefault("alignToInterval", 2, false)
 	if err != nil {
@@ -80,6 +84,7 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 			},
 			Tags: arg.Tags,
 		}
+		r.Tags["hitcount"] = intervalString
 
 		bucketEnd := start + bucketSize
 		t := arg.StartTime

--- a/expr/functions/holtWintersAberration/function.go
+++ b/expr/functions/holtWintersAberration/function.go
@@ -88,7 +88,7 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 			},
 			Tags: arg.Tags,
 		}
-
+		r.Tags["holtWintersAberration"] = "1"
 		results = append(results, &r)
 	}
 	return results, nil

--- a/expr/functions/holtWintersConfidenceBands/function.go
+++ b/expr/functions/holtWintersConfidenceBands/function.go
@@ -65,7 +65,7 @@ func (f *holtWintersConfidenceBands) Do(ctx context.Context, e parser.Expr, from
 			},
 			Tags: arg.Tags,
 		}
-		lowerSeries.Tags["holtWintersConfidenceBands"] = "1"
+		lowerSeries.Tags["holtWintersConfidenceLower"] = "1"
 
 		upperSeries := types.MetricData{
 			FetchResponse: pb.FetchResponse{
@@ -80,7 +80,7 @@ func (f *holtWintersConfidenceBands) Do(ctx context.Context, e parser.Expr, from
 			},
 			Tags: arg.Tags,
 		}
-		upperSeries.Tags["holtWintersConfidenceBands"] = "1"
+		upperSeries.Tags["holtWintersConfidenceUpper"] = "1"
 
 		results = append(results, &lowerSeries, &upperSeries)
 	}

--- a/expr/functions/holtWintersConfidenceBands/function.go
+++ b/expr/functions/holtWintersConfidenceBands/function.go
@@ -65,6 +65,7 @@ func (f *holtWintersConfidenceBands) Do(ctx context.Context, e parser.Expr, from
 			},
 			Tags: arg.Tags,
 		}
+		lowerSeries.Tags["holtWintersConfidenceBands"] = "1"
 
 		upperSeries := types.MetricData{
 			FetchResponse: pb.FetchResponse{
@@ -79,6 +80,7 @@ func (f *holtWintersConfidenceBands) Do(ctx context.Context, e parser.Expr, from
 			},
 			Tags: arg.Tags,
 		}
+		upperSeries.Tags["holtWintersConfidenceBands"] = "1"
 
 		results = append(results, &lowerSeries, &upperSeries)
 	}

--- a/expr/functions/holtWintersForecast/function.go
+++ b/expr/functions/holtWintersForecast/function.go
@@ -68,6 +68,8 @@ func (f *holtWintersForecast) Do(ctx context.Context, e parser.Expr, from, until
 			},
 			Tags: arg.Tags,
 		}
+		r.Tags["holtWintersConfidenceBands"] = "1"
+
 		results = append(results, &r)
 	}
 	return results, nil

--- a/expr/functions/integral/function.go
+++ b/expr/functions/integral/function.go
@@ -40,6 +40,7 @@ func (f *integral) Do(ctx context.Context, e parser.Expr, from, until int64, val
 			current += v
 			r.Values[i] = current
 		}
+		r.Tags["integral"] = "1"
 		return r
 	})
 }

--- a/expr/functions/integral/function_test.go
+++ b/expr/functions/integral/function_test.go
@@ -39,7 +39,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/integral/function_test.go
+++ b/expr/functions/integral/function_test.go
@@ -39,7 +39,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/integralByInterval/function.go
+++ b/expr/functions/integralByInterval/function.go
@@ -45,6 +45,10 @@ func (f *integralByInterval) Do(ctx context.Context, e parser.Expr, from, until 
 		return nil, err
 	}
 	bucketSize := int64(bucketSizeInt32)
+	intervalString, err := e.GetStringArg(1)
+	if err != nil {
+		return nil, err
+	}
 
 	startTime := from
 	results := make([]*types.MetricData, 0, len(args))
@@ -66,6 +70,8 @@ func (f *integralByInterval) Do(ctx context.Context, e parser.Expr, from, until 
 			},
 			Tags: arg.Tags,
 		}
+		result.Tags["integralByInterval"] = intervalString
+
 		for i, v := range arg.Values {
 			if (currentTime-startTime)/bucketSize != (currentTime-startTime-arg.StepTime)/bucketSize {
 				current = 0

--- a/expr/functions/integralByInterval/function_test.go
+++ b/expr/functions/integralByInterval/function_test.go
@@ -39,7 +39,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/integralByInterval/function_test.go
+++ b/expr/functions/integralByInterval/function_test.go
@@ -39,7 +39,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/invert/function.go
+++ b/expr/functions/invert/function.go
@@ -38,6 +38,8 @@ func (f *invert) Do(ctx context.Context, e parser.Expr, from, until int64, value
 				r.Values[i] = 1 / v
 			}
 		}
+		r.Tags["invert"] = "1"
+
 		return r
 	})
 }

--- a/expr/functions/invert/function_test.go
+++ b/expr/functions/invert/function_test.go
@@ -39,7 +39,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/invert/function_test.go
+++ b/expr/functions/invert/function_test.go
@@ -39,7 +39,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/isNotNull/function.go
+++ b/expr/functions/isNotNull/function.go
@@ -42,6 +42,7 @@ func (f *isNotNull) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			}
 
 		}
+		r.Tags["isNonNull"] = "1"
 		return r
 	})
 }

--- a/expr/functions/isNotNull/function_test.go
+++ b/expr/functions/isNotNull/function_test.go
@@ -52,7 +52,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/isNotNull/function_test.go
+++ b/expr/functions/isNotNull/function_test.go
@@ -52,7 +52,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/linearRegression/function.go
+++ b/expr/functions/linearRegression/function.go
@@ -88,6 +88,8 @@ func (f *linearRegression) Do(ctx context.Context, e parser.Expr, from, until in
 		for i := range r.Values {
 			r.Values[i] = consolidations.Poly(float64(i), c.RawMatrix().Data...)
 		}
+		r.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", a.GetStartTime(), a.GetStopTime())
+
 		results = append(results, &r)
 	}
 	return results, nil

--- a/expr/functions/linearRegression/function_test.go
+++ b/expr/functions/linearRegression/function_test.go
@@ -44,7 +44,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/linearRegression/function_test.go
+++ b/expr/functions/linearRegression/function_test.go
@@ -44,7 +44,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/logarithm/function.go
+++ b/expr/functions/logarithm/function.go
@@ -61,6 +61,7 @@ func (f *logarithm) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		r := *a
 		r.Name = name
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["log"] = fmt.Sprintf("%f", baseLog)
 
 		for i, v := range a.Values {
 			r.Values[i] = math.Log(v) / baseLog

--- a/expr/functions/logarithm/function_test.go
+++ b/expr/functions/logarithm/function_test.go
@@ -46,7 +46,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/logarithm/function_test.go
+++ b/expr/functions/logarithm/function_test.go
@@ -46,7 +46,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -161,6 +161,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			}
 			w.Push(v)
 		}
+		r.Tags[e.Target()] = fmt.Sprintf("%d", windowSize)
 		result = append(result, &r)
 	}
 	return result, nil

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -73,7 +73,11 @@ func TestMoving(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -73,7 +73,7 @@ func TestMoving(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -147,6 +147,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 				}
 			}
 		}
+		r.Tags["movingMedian"] = fmt.Sprintf("%d", windowSize)
 		result = append(result, &r)
 	}
 	return result, nil

--- a/expr/functions/movingMedian/function_test.go
+++ b/expr/functions/movingMedian/function_test.go
@@ -66,7 +66,7 @@ func TestMovingMedian(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/movingMedian/function_test.go
+++ b/expr/functions/movingMedian/function_test.go
@@ -66,7 +66,11 @@ func TestMovingMedian(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/multiplySeriesWithWildcards/function.go
+++ b/expr/functions/multiplySeriesWithWildcards/function.go
@@ -3,7 +3,6 @@ package multiplySeriesWithWildcards
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/carbonapi/expr/tags"
 	"math"
 	"strings"
 
@@ -72,7 +71,7 @@ func (f *multiplySeriesWithWildcards) Do(ctx context.Context, e parser.Expr, fro
 		groups[node] = append(groups[node], a)
 	}
 
-	commonTags := tags.CopyTags(args[0])
+	commonTags := helper.CopyTags(args[0])
 	for _, serie := range args {
 		for k, v := range serie.Tags {
 			if commonTags[k] != v {

--- a/expr/functions/multiplySeriesWithWildcards/function.go
+++ b/expr/functions/multiplySeriesWithWildcards/function.go
@@ -71,14 +71,7 @@ func (f *multiplySeriesWithWildcards) Do(ctx context.Context, e parser.Expr, fro
 		groups[node] = append(groups[node], a)
 	}
 
-	commonTags := helper.CopyTags(args[0])
-	for _, serie := range args {
-		for k, v := range serie.Tags {
-			if commonTags[k] != v {
-				delete(commonTags, k)
-			}
-		}
-	}
+	commonTags := helper.GetCommonTags(args)
 
 	for _, series := range nodeList {
 		args := groups[series]
@@ -89,6 +82,10 @@ func (f *multiplySeriesWithWildcards) Do(ctx context.Context, e parser.Expr, fro
 			r.Tags[k] = v
 		}
 		r.Tags["name"] = series
+		if _, ok := commonTags["name"]; !ok {
+			commonTags["name"] = r.Name
+		}
+		r.Tags = commonTags
 		r.Values = make([]float64, len(args[0].Values))
 
 		atLeastOne := make([]bool, len(args[0].Values))

--- a/expr/functions/nPercentile/function.go
+++ b/expr/functions/nPercentile/function.go
@@ -46,7 +46,7 @@ func (f *nPercentile) Do(ctx context.Context, e parser.Expr, from, until int64, 
 		r := *a
 		r.Name = fmt.Sprintf("nPercentile(%s,%g)", a.Name, percent)
 		r.Values = make([]float64, len(a.Values))
-		r.Tags["nPercentile"] = fmt.Sprintf("%d", percent)
+		r.Tags["nPercentile"] = fmt.Sprintf("%f", percent)
 		var values []float64
 		for _, v := range a.Values {
 			if !math.IsNaN(v) {

--- a/expr/functions/nPercentile/function.go
+++ b/expr/functions/nPercentile/function.go
@@ -46,7 +46,7 @@ func (f *nPercentile) Do(ctx context.Context, e parser.Expr, from, until int64, 
 		r := *a
 		r.Name = fmt.Sprintf("nPercentile(%s,%g)", a.Name, percent)
 		r.Values = make([]float64, len(a.Values))
-
+		r.Tags["nPercentile"] = fmt.Sprintf("%d", percent)
 		var values []float64
 		for _, v := range a.Values {
 			if !math.IsNaN(v) {

--- a/expr/functions/nPercentile/function_test.go
+++ b/expr/functions/nPercentile/function_test.go
@@ -38,7 +38,7 @@ func TestNPercentile(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/nPercentile/function_test.go
+++ b/expr/functions/nPercentile/function_test.go
@@ -38,7 +38,11 @@ func TestNPercentile(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/nonNegativeDerivative/function.go
+++ b/expr/functions/nonNegativeDerivative/function.go
@@ -79,6 +79,7 @@ func (f *nonNegativeDerivative) Do(ctx context.Context, e parser.Expr, from, unt
 		r := *a
 		r.Name = name
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["nonNegativeDerivative"] = "1"
 
 		prev := a.Values[0]
 		for i, v := range a.Values {

--- a/expr/functions/nonNegativeDerivative/function_test.go
+++ b/expr/functions/nonNegativeDerivative/function_test.go
@@ -59,7 +59,11 @@ func TestNonNegativeDerivative(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/nonNegativeDerivative/function_test.go
+++ b/expr/functions/nonNegativeDerivative/function_test.go
@@ -59,7 +59,7 @@ func TestNonNegativeDerivative(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/offset/function.go
+++ b/expr/functions/offset/function.go
@@ -44,6 +44,7 @@ func (f *offset) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		r := *a
 		r.Name = fmt.Sprintf("%s(%s,%g)", e.Target(), a.Name, factor)
 		r.Values = make([]float64, len(a.Values))
+		r.Tags[e.Target()] = fmt.Sprintf("%f", factor)
 
 		for i, v := range a.Values {
 			r.Values[i] = v + factor

--- a/expr/functions/offset/function_test.go
+++ b/expr/functions/offset/function_test.go
@@ -52,7 +52,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/offset/function_test.go
+++ b/expr/functions/offset/function_test.go
@@ -52,7 +52,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/offsetToZero/function.go
+++ b/expr/functions/offsetToZero/function.go
@@ -42,7 +42,7 @@ func (f *offsetToZero) Do(ctx context.Context, e parser.Expr, from, until int64,
 		for i, v := range a.Values {
 			r.Values[i] = v - minimum
 		}
-		r.Tags["offsetToZero"] = fmt.Sprintf("%d", minimum)
+		r.Tags["offsetToZero"] = fmt.Sprintf("%f", minimum)
 		return r
 	})
 }

--- a/expr/functions/offsetToZero/function.go
+++ b/expr/functions/offsetToZero/function.go
@@ -2,6 +2,7 @@ package offsetToZero
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	"github.com/grafana/carbonapi/expr/helper"
@@ -41,6 +42,7 @@ func (f *offsetToZero) Do(ctx context.Context, e parser.Expr, from, until int64,
 		for i, v := range a.Values {
 			r.Values[i] = v - minimum
 		}
+		r.Tags["offsetToZero"] = fmt.Sprintf("%d", minimum)
 		return r
 	})
 }

--- a/expr/functions/offsetToZero/function_test.go
+++ b/expr/functions/offsetToZero/function_test.go
@@ -39,7 +39,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/offsetToZero/function_test.go
+++ b/expr/functions/offsetToZero/function_test.go
@@ -39,7 +39,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/perSecond/function.go
+++ b/expr/functions/perSecond/function.go
@@ -81,6 +81,7 @@ func (f *perSecond) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		r := *a
 		r.Name = name
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["perSecond"] = "1"
 
 		prev := a.Values[0]
 		for i, v := range a.Values {

--- a/expr/functions/perSecond/function_test.go
+++ b/expr/functions/perSecond/function_test.go
@@ -52,7 +52,7 @@ func TestPerSecond(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/perSecond/function_test.go
+++ b/expr/functions/perSecond/function_test.go
@@ -52,7 +52,11 @@ func TestPerSecond(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/pow/function.go
+++ b/expr/functions/pow/function.go
@@ -45,6 +45,7 @@ func (f *pow) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 		r := *a
 		r.Name = fmt.Sprintf("pow(%s,%g)", a.Name, factor)
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["pow"] = fmt.Sprintf("%f", factor)
 
 		for i, v := range a.Values {
 			if math.IsNaN(v) {

--- a/expr/functions/pow/function_test.go
+++ b/expr/functions/pow/function_test.go
@@ -45,7 +45,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/pow/function_test.go
+++ b/expr/functions/pow/function_test.go
@@ -45,7 +45,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/rangeOfSeries/function.go
+++ b/expr/functions/rangeOfSeries/function.go
@@ -40,14 +40,8 @@ func (f *rangeOfSeries) Do(ctx context.Context, e parser.Expr, from, until int64
 	r.Name = fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
 	r.Values = make([]float64, len(series[0].Values))
 
-	commonTags := helper.CopyTags(series[0])
-	for _, serie := range series {
-		for k, v := range serie.Tags {
-			if commonTags[k] != v {
-				delete(commonTags, k)
-			}
-		}
-	}
+	commonTags := helper.GetCommonTags(series)
+
 	if _, ok := commonTags["name"]; !ok {
 		commonTags["name"] = r.Name
 	}

--- a/expr/functions/rangeOfSeries/function.go
+++ b/expr/functions/rangeOfSeries/function.go
@@ -3,7 +3,6 @@ package rangeOfSeries
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/carbonapi/expr/tags"
 	"math"
 
 	"github.com/grafana/carbonapi/expr/helper"
@@ -41,7 +40,7 @@ func (f *rangeOfSeries) Do(ctx context.Context, e parser.Expr, from, until int64
 	r.Name = fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
 	r.Values = make([]float64, len(series[0].Values))
 
-	commonTags := tags.CopyTags(series[0])
+	commonTags := helper.CopyTags(series[0])
 	for _, serie := range series {
 		for k, v := range serie.Tags {
 			if commonTags[k] != v {

--- a/expr/functions/rangeOfSeries/function_test.go
+++ b/expr/functions/rangeOfSeries/function_test.go
@@ -43,7 +43,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/rangeOfSeries/function_test.go
+++ b/expr/functions/rangeOfSeries/function_test.go
@@ -43,7 +43,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/removeBelowSeries/function.go
+++ b/expr/functions/removeBelowSeries/function.go
@@ -71,6 +71,7 @@ func (f *removeBelowSeries) Do(ctx context.Context, e parser.Expr, from, until i
 		r := *a
 		r.Name = fmt.Sprintf("%s(%s, %g)", e.Target(), a.Name, number)
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["removeBelowSeries"] = fmt.Sprintf("%f", threshold)
 
 		for i, v := range a.Values {
 			if math.IsNaN(v) || condition(v, threshold) {

--- a/expr/functions/removeBelowSeries/function_test.go
+++ b/expr/functions/removeBelowSeries/function_test.go
@@ -63,7 +63,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/removeBelowSeries/function_test.go
+++ b/expr/functions/removeBelowSeries/function_test.go
@@ -63,7 +63,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/removeEmptySeries/function.go
+++ b/expr/functions/removeEmptySeries/function.go
@@ -57,7 +57,7 @@ func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until i
 				}
 			}
 		}
-		arg.Tags["round"] = fmt.Sprintf("%f", factor)
+		arg.Tags[e.Target()] = fmt.Sprintf("%f", factor)
 		if nonNull != 0 && nonNull/float64(len(arg.Values)) >= factor {
 			results = append(results, arg)
 		}

--- a/expr/functions/removeEmptySeries/function.go
+++ b/expr/functions/removeEmptySeries/function.go
@@ -2,6 +2,7 @@ package removeEmptySeries
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	"github.com/grafana/carbonapi/expr/helper"
@@ -56,6 +57,7 @@ func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until i
 				}
 			}
 		}
+		arg.Tags["round"] = fmt.Sprintf("%f", factor)
 		if nonNull != 0 && nonNull/float64(len(arg.Values)) >= factor {
 			results = append(results, arg)
 		}

--- a/expr/functions/removeEmptySeries/function_test.go
+++ b/expr/functions/removeEmptySeries/function_test.go
@@ -114,7 +114,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/removeEmptySeries/function_test.go
+++ b/expr/functions/removeEmptySeries/function_test.go
@@ -114,7 +114,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/round/function.go
+++ b/expr/functions/round/function.go
@@ -54,6 +54,7 @@ func (f *round) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		for i, v := range a.Values {
 			r.Values[i] = doRound(v, precision)
 		}
+		r.Tags["round"] = precision
 		results = append(results, &r)
 	}
 	return results, nil

--- a/expr/functions/round/function.go
+++ b/expr/functions/round/function.go
@@ -54,7 +54,7 @@ func (f *round) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		for i, v := range a.Values {
 			r.Values[i] = doRound(v, precision)
 		}
-		r.Tags["round"] = precision
+		r.Tags["round"] = fmt.Sprintf("%d", precision)
 		results = append(results, &r)
 	}
 	return results, nil

--- a/expr/functions/round/function_test.go
+++ b/expr/functions/round/function_test.go
@@ -73,7 +73,11 @@ func TestHeatMap(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 }

--- a/expr/functions/round/function_test.go
+++ b/expr/functions/round/function_test.go
@@ -73,7 +73,7 @@ func TestHeatMap(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 }

--- a/expr/functions/scale/function.go
+++ b/expr/functions/scale/function.go
@@ -52,6 +52,7 @@ func (f *scale) Do(ctx context.Context, e parser.Expr, from, until int64, values
 			r.Name = fmt.Sprintf("scale(%s,%g,%d)", a.Name, scale, timestamp)
 		}
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["scale"] = fmt.Sprintf("%f", scale)
 
 		currentTimestamp := a.StartTime
 		for i, v := range a.Values {

--- a/expr/functions/scale/function_test.go
+++ b/expr/functions/scale/function_test.go
@@ -64,7 +64,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/scale/function_test.go
+++ b/expr/functions/scale/function_test.go
@@ -64,7 +64,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/scaleToSeconds/function.go
+++ b/expr/functions/scaleToSeconds/function.go
@@ -45,6 +45,7 @@ func (f *scaleToSeconds) Do(ctx context.Context, e parser.Expr, from, until int6
 		r := *a
 		r.Name = fmt.Sprintf("scaleToSeconds(%s,%d)", a.Name, int(seconds))
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["scaleToSeconds"] = fmt.Sprintf("%f", seconds)
 
 		factor := seconds / float64(a.StepTime)
 

--- a/expr/functions/scaleToSeconds/function_test.go
+++ b/expr/functions/scaleToSeconds/function_test.go
@@ -38,7 +38,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/scaleToSeconds/function_test.go
+++ b/expr/functions/scaleToSeconds/function_test.go
@@ -38,7 +38,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -44,10 +44,6 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 		return nil, err
 	}
 	bucketSize := int64(bucketSizeInt32)
-	intervalString, err := e.GetStringArg(1)
-	if err != nil {
-		return nil, err
-	}
 
 	summarizeFunction, err := e.GetStringNamedOrPosArgDefault("func", 2, "sum")
 	if err != nil {
@@ -90,7 +86,7 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 			},
 			Tags: arg.Tags,
 		}
-		r.Tags["smartSummarize"] = intervalString
+		r.Tags["smartSummarize"] = fmt.Sprintf("%d", bucketSizeInt32)
 		r.Tags["smartSummarizeFunction"] = summarizeFunction
 		t := arg.StartTime // unadjusted
 		bucketEnd := start + bucketSize

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -44,6 +44,10 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 		return nil, err
 	}
 	bucketSize := int64(bucketSizeInt32)
+	intervalString, err := e.GetStringArg(1)
+	if err != nil {
+		return nil, err
+	}
 
 	summarizeFunction, err := e.GetStringNamedOrPosArgDefault("func", 2, "sum")
 	if err != nil {
@@ -86,7 +90,8 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 			},
 			Tags: arg.Tags,
 		}
-
+		r.Tags["smartSummarize"] = intervalString
+		r.Tags["smartSummarizeFunction"] = summarizeFunction
 		t := arg.StartTime // unadjusted
 		bucketEnd := start + bucketSize
 		values := make([]float64, 0, bucketSize/arg.StepTime)

--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -106,7 +106,11 @@ func TestFunctionUseNameWithWildcards(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestMultiReturnEvalExprModifiedOrigin(t, &tt)
+			err := th.TestMultiReturnEvalExprModifiedOrigin(t, &tt)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 }

--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -106,7 +106,7 @@ func TestFunctionUseNameWithWildcards(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestMultiReturnEvalExpr(t, &tt)
+			th.TestMultiReturnEvalExprModifiedOrigin(t, &tt)
 		})
 	}
 }

--- a/expr/functions/squareRoot/function.go
+++ b/expr/functions/squareRoot/function.go
@@ -41,6 +41,7 @@ func (f *squareRoot) Do(ctx context.Context, e parser.Expr, from, until int64, v
 		r := *a
 		r.Name = fmt.Sprintf("squareRoot(%s)", a.Name)
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["squareRoot"] = "1"
 
 		for i, v := range a.Values {
 			r.Values[i] = math.Sqrt(v)

--- a/expr/functions/squareRoot/function_test.go
+++ b/expr/functions/squareRoot/function_test.go
@@ -39,7 +39,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 

--- a/expr/functions/squareRoot/function_test.go
+++ b/expr/functions/squareRoot/function_test.go
@@ -39,7 +39,11 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 

--- a/expr/functions/stdev/function.go
+++ b/expr/functions/stdev/function.go
@@ -54,6 +54,7 @@ func (f *stdev) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		r := *a
 		r.Name = fmt.Sprintf("stdev(%s,%d)", a.Name, points)
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["stdev"] = fmt.Sprintf("%f", points)
 
 		for i, v := range a.Values {
 			w.Push(v)

--- a/expr/functions/stdev/function.go
+++ b/expr/functions/stdev/function.go
@@ -54,7 +54,7 @@ func (f *stdev) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		r := *a
 		r.Name = fmt.Sprintf("stdev(%s,%d)", a.Name, points)
 		r.Values = make([]float64, len(a.Values))
-		r.Tags["stdev"] = fmt.Sprintf("%f", points)
+		r.Tags["stdev"] = fmt.Sprintf("%d", points)
 
 		for i, v := range a.Values {
 			w.Push(v)

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -46,8 +46,11 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	if err != nil {
 		return nil, err
 	}
-
 	bucketSize := int64(bucketSizeInt32)
+	intervalString, err := e.GetStringArg(1)
+	if err != nil {
+		return nil, err
+	}
 
 	summarizeFunction, err := e.GetStringNamedOrPosArgDefault("func", 2, "sum")
 	if err != nil {
@@ -125,6 +128,8 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			},
 			Tags: arg.Tags,
 		}
+		r.Tags["summarize"] = intervalString
+		r.Tags["summarizeFunction"] = summarizeFunction
 
 		t := arg.StartTime // unadjusted
 		bucketEnd := start + bucketSize

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -47,10 +47,6 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		return nil, err
 	}
 	bucketSize := int64(bucketSizeInt32)
-	intervalString, err := e.GetStringArg(1)
-	if err != nil {
-		return nil, err
-	}
 
 	summarizeFunction, err := e.GetStringNamedOrPosArgDefault("func", 2, "sum")
 	if err != nil {
@@ -128,7 +124,7 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			},
 			Tags: arg.Tags,
 		}
-		r.Tags["summarize"] = intervalString
+		r.Tags["summarize"] = fmt.Sprintf("%d", bucketSizeInt32)
 		r.Tags["summarizeFunction"] = summarizeFunction
 
 		t := arg.StartTime // unadjusted

--- a/expr/functions/timeShift/function.go
+++ b/expr/functions/timeShift/function.go
@@ -104,6 +104,7 @@ func (f *timeShift) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			continue
 		}
 		r.Values = r.Values[:length]
+		r.Tags["timeshift"] = fmt.Sprintf("%d", offs)
 		results = append(results, &r)
 	}
 

--- a/expr/functions/timeShift/function_test.go
+++ b/expr/functions/timeShift/function_test.go
@@ -100,7 +100,7 @@ func TestTimeShift(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprWithRange(t, &tt)
+			th.TestEvalExprWithRangeModifiedOrigin(t, &tt)
 		})
 	}
 }

--- a/expr/functions/timeSlice/function.go
+++ b/expr/functions/timeSlice/function.go
@@ -56,6 +56,8 @@ func (f *timeSlice) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		r := *a
 		r.Name = fmt.Sprintf("timeSlice(%s, %d, %d)", a.Name, start, end)
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["timeSliceStart"] = fmt.Sprintf("%d", start)
+		r.Tags["timeSliceEnd"] = fmt.Sprintf("%d", end)
 
 		current := from
 		for i, v := range a.Values {

--- a/expr/functions/timeStack/function.go
+++ b/expr/functions/timeStack/function.go
@@ -60,6 +60,8 @@ func (f *timeStack) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			r.Name = fmt.Sprintf("timeShift(%s,%d)", a.Name, offs)
 			r.StartTime = a.StartTime - offs
 			r.StopTime = a.StopTime - offs
+			r.Tags["timeShiftUnit"] = fmt.Sprintf("%d", unit)
+			r.Tags["timeShift"] = fmt.Sprintf("%d", offs)
 			results = append(results, &r)
 		}
 	}

--- a/expr/functions/transformNull/function.go
+++ b/expr/functions/transformNull/function.go
@@ -89,6 +89,7 @@ func (f *transformNull) Do(ctx context.Context, e parser.Expr, from, until int64
 		r := *a
 		r.Name = name
 		r.Values = make([]float64, len(a.Values))
+		r.Tags["transformNull"] = fmt.Sprintf("%f", defv)
 
 		for i, v := range a.Values {
 			if math.IsNaN(v) {

--- a/expr/functions/transformNull/function_test.go
+++ b/expr/functions/transformNull/function_test.go
@@ -64,7 +64,7 @@ func TestTransformNull(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
 		})
 	}
 }

--- a/expr/functions/transformNull/function_test.go
+++ b/expr/functions/transformNull/function_test.go
@@ -64,7 +64,11 @@ func TestTransformNull(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+			if err != nil {
+				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+				return
+			}
 		})
 	}
 }

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -3,7 +3,6 @@ package helper
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/carbonapi/expr/tags"
 	"math"
 	"regexp"
 	"strings"
@@ -160,7 +159,7 @@ func AggregateSeries(e parser.Expr, args []*types.MetricData, function Aggregate
 	r.Name = fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
 	r.Values = make([]float64, length)
 
-	commonTags := tags.CopyTags(args[0])
+	commonTags := CopyTags(args[0])
 	for _, serie := range args {
 		for k, v := range serie.Tags {
 			if commonTags[k] != v {
@@ -168,7 +167,7 @@ func AggregateSeries(e parser.Expr, args []*types.MetricData, function Aggregate
 			}
 		}
 	}
-	
+
 	if _, ok := commonTags["name"]; !ok {
 		commonTags["name"] = r.Name
 	}
@@ -252,4 +251,13 @@ func Contains(a []int, i int) bool {
 		}
 	}
 	return false
+}
+
+// CopyTags makes a deep copy of the tags
+func CopyTags(series *types.MetricData) map[string]string {
+	out := make(map[string]string, len(series.Tags))
+	for k, v := range series.Tags {
+		out[k] = v
+	}
+	return out
 }

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -159,14 +159,7 @@ func AggregateSeries(e parser.Expr, args []*types.MetricData, function Aggregate
 	r.Name = fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
 	r.Values = make([]float64, length)
 
-	commonTags := CopyTags(args[0])
-	for _, serie := range args {
-		for k, v := range serie.Tags {
-			if commonTags[k] != v {
-				delete(commonTags, k)
-			}
-		}
-	}
+	commonTags := GetCommonTags(args)
 
 	if _, ok := commonTags["name"]; !ok {
 		commonTags["name"] = r.Name
@@ -260,4 +253,17 @@ func CopyTags(series *types.MetricData) map[string]string {
 		out[k] = v
 	}
 	return out
+}
+
+func GetCommonTags(series []*types.MetricData) map[string]string {
+	commonTags := CopyTags(series[0])
+	for _, serie := range series {
+		for k, v := range serie.Tags {
+			if commonTags[k] != v {
+				delete(commonTags, k)
+			}
+		}
+	}
+
+	return commonTags
 }

--- a/expr/tags/helper.go
+++ b/expr/tags/helper.go
@@ -2,6 +2,8 @@ package tags
 
 import (
 	"strings"
+
+	"github.com/grafana/carbonapi/expr/types"
 )
 
 // ExtractTags extracts all graphite-style tags out of metric name
@@ -59,4 +61,13 @@ func ExtractTags(s string) map[string]string {
 	}
 
 	return result
+}
+
+// CopyTags makes a deep copy of the tags
+func CopyTags(series *types.MetricData) map[string]string {
+	out := make(map[string]string, len(series.Tags))
+	for k, v := range series.Tags {
+		out[k] = v
+	}
+	return out
 }

--- a/expr/tags/helper.go
+++ b/expr/tags/helper.go
@@ -2,8 +2,6 @@ package tags
 
 import (
 	"strings"
-
-	"github.com/grafana/carbonapi/expr/types"
 )
 
 // ExtractTags extracts all graphite-style tags out of metric name
@@ -61,13 +59,4 @@ func ExtractTags(s string) map[string]string {
 	}
 
 	return result
-}
-
-// CopyTags makes a deep copy of the tags
-func CopyTags(series *types.MetricData) map[string]string {
-	out := make(map[string]string, len(series.Tags))
-	for k, v := range series.Tags {
-		out[k] = v
-	}
-	return out
 }

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -412,6 +412,51 @@ func TestMultiReturnEvalExpr(t *testing.T, tt *MultiReturnEvalTestItem) {
 	}
 }
 
+func TestMultiReturnEvalExprModifiedOrigin(t *testing.T, tt *MultiReturnEvalTestItem) {
+	evaluator := metadata.GetEvaluator()
+
+	exp, _, err := parser.ParseExpr(tt.Target)
+	if err != nil {
+		t.Errorf("failed to parse %v: %+v", tt.Target, err)
+		return
+	}
+	g, err := evaluator.Eval(context.Background(), exp, 0, 1, tt.M)
+	if err != nil {
+		t.Errorf("failed to eval %v: %+v", tt.Name, err)
+		return
+	}
+	if len(g) == 0 {
+		t.Errorf("returned no data %v", tt.Name)
+		return
+	}
+	if g[0] == nil {
+		t.Errorf("returned no value %v", tt.Name)
+		return
+	}
+	if g[0].StepTime == 0 {
+		t.Errorf("missing Step for %+v", g)
+	}
+	if len(g) != len(tt.Results) {
+		t.Errorf("unexpected results len: got %d, want %d for %s", len(g), len(tt.Results), tt.Target)
+	}
+	for _, gg := range g {
+		r, ok := tt.Results[gg.Name]
+		if !ok {
+			t.Errorf("missing result Name: %v", gg.Name)
+			continue
+		}
+		if r[0].Name != gg.Name {
+			t.Errorf("result Name mismatch, got\n%#v,\nwant\n%#v", gg.Name, r[0].Name)
+		}
+		if !reflect.DeepEqual(r[0].Values, gg.Values) ||
+			r[0].StartTime != gg.StartTime ||
+			r[0].StopTime != gg.StopTime ||
+			r[0].StepTime != gg.StepTime {
+			t.Errorf("result mismatch, got\n%#v,\nwant\n%#v", gg, r)
+		}
+	}
+}
+
 type RewriteTestResult struct {
 	Rewritten bool
 	Targets   []string
@@ -567,6 +612,15 @@ func TestEvalExprWithRange(t *testing.T, tt *EvalTestItemWithRange) {
 		return
 	}
 	DeepEqual(t, tt.Target, originalMetrics, tt.M, true)
+}
+
+func TestEvalExprWithRangeModifiedOrigin(t *testing.T, tt *EvalTestItemWithRange) {
+	tt2 := tt.TestItem()
+	err := TestEvalExprModifiedOrigin(t, tt2, tt.From, tt.Until, false)
+	if err != nil {
+		t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
+		return
+	}
 }
 
 func TestEvalExprWithError(t *testing.T, tt *EvalTestItemWithError) {

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -412,26 +412,26 @@ func TestMultiReturnEvalExpr(t *testing.T, tt *MultiReturnEvalTestItem) {
 	}
 }
 
-func TestMultiReturnEvalExprModifiedOrigin(t *testing.T, tt *MultiReturnEvalTestItem) {
+func TestMultiReturnEvalExprModifiedOrigin(t *testing.T, tt *MultiReturnEvalTestItem) error {
 	evaluator := metadata.GetEvaluator()
 
 	exp, _, err := parser.ParseExpr(tt.Target)
 	if err != nil {
 		t.Errorf("failed to parse %v: %+v", tt.Target, err)
-		return
+		return err
 	}
 	g, err := evaluator.Eval(context.Background(), exp, 0, 1, tt.M)
 	if err != nil {
 		t.Errorf("failed to eval %v: %+v", tt.Name, err)
-		return
+		return err
 	}
 	if len(g) == 0 {
 		t.Errorf("returned no data %v", tt.Name)
-		return
+		return nil
 	}
 	if g[0] == nil {
 		t.Errorf("returned no value %v", tt.Name)
-		return
+		return nil
 	}
 	if g[0].StepTime == 0 {
 		t.Errorf("missing Step for %+v", g)
@@ -455,6 +455,8 @@ func TestMultiReturnEvalExprModifiedOrigin(t *testing.T, tt *MultiReturnEvalTest
 			t.Errorf("result mismatch, got\n%#v,\nwant\n%#v", gg, r)
 		}
 	}
+
+	return nil
 }
 
 type RewriteTestResult struct {


### PR DESCRIPTION
This PR updates expr functions to add function-specific tags to match Graphite web functions.