### PR TITLE
Add support for Graphite web removeBetweenPercentile() function

### DIFF
--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -76,6 +76,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/rangeOfSeries"
 	"github.com/grafana/carbonapi/expr/functions/reduce"
 	"github.com/grafana/carbonapi/expr/functions/removeBelowSeries"
+	"github.com/grafana/carbonapi/expr/functions/removeBetweenPercentile"
 	"github.com/grafana/carbonapi/expr/functions/removeEmptySeries"
 	"github.com/grafana/carbonapi/expr/functions/round"
 	"github.com/grafana/carbonapi/expr/functions/scale"
@@ -184,6 +185,7 @@ func New(configs map[string]string) {
 		{name: "rangeOfSeries", filename: "rangeOfSeries", order: rangeOfSeries.GetOrder(), f: rangeOfSeries.New},
 		{name: "reduce", filename: "reduce", order: reduce.GetOrder(), f: reduce.New},
 		{name: "removeBelowSeries", filename: "removeBelowSeries", order: removeBelowSeries.GetOrder(), f: removeBelowSeries.New},
+		{name: "removeBetweenPercentile", filename: "removeBetweenPercentile", order: removeBetweenPercentile.GetOrder(), f: removeBetweenPercentile.New},
 		{name: "removeEmptySeries", filename: "removeEmptySeries", order: removeEmptySeries.GetOrder(), f: removeEmptySeries.New},
 		{name: "round", filename: "round", order: round.GetOrder(), f: round.New},
 		{name: "scale", filename: "scale", order: scale.GetOrder(), f: scale.New},

--- a/expr/functions/removeBetweenPercentile/function.go
+++ b/expr/functions/removeBetweenPercentile/function.go
@@ -1,0 +1,101 @@
+package removeBetweenPercentile
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/grafana/carbonapi/expr/consolidations"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+)
+
+type removeBetweenPercentile struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &removeBetweenPercentile{}
+	functions := []string{"removeBetweenPercentile"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// removeBetweenPercentile(seriesLists, percent)
+func (f *removeBetweenPercentile) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	number, err := e.GetFloatArg(1)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*types.MetricData
+
+	if number < 50.0 {
+		number = 100.0 - number
+	}
+
+	var lowerThresholds []float64
+	var higherThresholds []float64
+
+	for i := range args[0].Values {
+		var values []float64
+		for _, arg := range args {
+			if !math.IsNaN(arg.Values[i]) {
+				values = append(values, arg.Values[i])
+			}
+		}
+		if len(values) > 0 {
+			lowerThresholds = append(lowerThresholds, consolidations.Percentile(values, (100.0-number), false))
+			higherThresholds = append(higherThresholds, consolidations.Percentile(values, number, false))
+		}
+	}
+
+	for i, a := range args {
+		for _, v := range a.Values {
+			if !(v > lowerThresholds[i] && v < higherThresholds[i]) {
+				results = append(results, a)
+				break
+			}
+		}
+	}
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *removeBetweenPercentile) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"removeBetweenPercentile": {
+			Description: "Removes series that do not have an value lying in the x-percentile of all the values at a moment",
+			Function:    "removeBetweenPercentile(seriesList, n)",
+			Group:       "Filter Data",
+			Module:      "graphite.render.functions",
+			Name:        "removeBetweenPercentile",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "n",
+					Required: true,
+					Type:     types.Integer,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/removeBetweenPercentile/function_test.go
+++ b/expr/functions/removeBetweenPercentile/function_test.go
@@ -1,0 +1,53 @@
+package removeBetweenPercentile
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/metadata"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+	th "github.com/grafana/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestFunction(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			`removeBetweenPercentile(metric[1234], 30)`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[1234]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{7, 7, 7, 7, 7, 7}, 1, now32),
+					types.MakeMetricData("metric2", []float64{5, 5, 5, 5, 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{10, 10, 10, 10, 10, 10}, 1, now32),
+					types.MakeMetricData("metric4", []float64{1, 1, 1, 1, 1, 1}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric2", []float64{5, 5, 5, 5, 5, 5}, 1, now32),
+				types.MakeMetricData("metric3", []float64{10, 10, 10, 10, 10, 10}, 1, now32),
+				types.MakeMetricData("metric4", []float64{1, 1, 1, 1, 1, 1}, 1, now32),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}

--- a/expr/functions/removeBetweenPercentile/function_test.go
+++ b/expr/functions/removeBetweenPercentile/function_test.go
@@ -36,9 +36,9 @@ func TestFunction(t *testing.T) {
 				},
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("metric2", []float64{5, 5, 5, 5, 5, 5}, 1, now32),
-				types.MakeMetricData("metric3", []float64{10, 10, 10, 10, 10, 10}, 1, now32),
-				types.MakeMetricData("metric4", []float64{1, 1, 1, 1, 1, 1}, 1, now32),
+				types.MakeMetricData("removeBetweenPercentile(metric2, 30)", []float64{5, 5, 5, 5, 5, 5}, 1, now32),
+				types.MakeMetricData("removeBetweenPercentile(metric3, 30)", []float64{10, 10, 10, 10, 10, 10}, 1, now32),
+				types.MakeMetricData("removeBetweenPercentile(metric4, 30)", []float64{1, 1, 1, 1, 1, 1}, 1, now32),
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds support for the Graphite web removeBetweenPercentile() function.

The removeBetweenPercentile function is defined as: 

```
removeBetweenPercentile(seriesList, n)
Removes series that do not have an value lying in the x-percentile of all the values at a moment
```

The Graphite web implementation is [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L3524)