### PR TITLE
Add support for Graphite web movingWindow() function

### DIFF
--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -122,7 +122,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		}
 
 		if len(e.Args()) == 4 {
-			xFilesFactor, err = e.GetFloatArgDefault(2, float64(arg[0].XFilesFactor))
+			xFilesFactor, err = e.GetFloatArgDefault(3, float64(arg[0].XFilesFactor))
 
 			if err != nil {
 				return nil, err

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -81,13 +81,6 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		return nil, parser.ErrMissingArgument
 	}
 
-	if len(e.Args()) == 3 {
-		cons, err = e.GetStringArgDefault(2, "average")
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	switch e.Args()[1].Type() {
 	case parser.EtConst:
 		// In this case, zipper does not request additional retrospective points,
@@ -119,7 +112,20 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		return nil, err
 	}
 
-	if len(e.Args()) == 3 {
+	if len(e.Args()) >= 3 && e.Target() == "movingWindow" {
+		cons, err = e.GetStringArgDefault(2, "average")
+		if err != nil {
+			return nil, err
+		}
+
+		if len(e.Args()) == 4 {
+			xFilesFactor, err = e.GetFloatArgDefault(2, float64(arg[0].XFilesFactor))
+
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else if len(e.Args()) == 3 {
 		xFilesFactor, err = e.GetFloatArgDefault(2, float64(arg[0].XFilesFactor))
 
 		if err != nil {
@@ -164,29 +170,29 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 				if helper.XFilesFactorValues(w.Data, xFilesFactor) {
 					switch e.Target() {
 					case "movingWindow":
-						if func == "average" || func == "avg" {
+						if cons == "average" || cons == "avg" {
 							r.Values[ridx] = w.Mean()
-						} else if func == "avg_zero" {
+						} else if cons == "avg_zero" {
 							r.Values[ridx] = w.MeanZero()
-						} else if func == "sum" {
+						} else if cons == "sum" {
 							r.Values[ridx] = w.Sum()
-						} else if func == "min" {
+						} else if cons == "min" {
 							r.Values[ridx] = w.Min()
-						} else if func == "max" {
+						} else if cons == "max" {
 							r.Values[ridx] = w.Max()
-						} else if func == "multiply" {
+						} else if cons == "multiply" {
 							r.Values[ridx] = w.Multiply()
-						} else if func == "range" {
+						} else if cons == "range" {
 							r.Values[ridx] = w.Range()
-						} else if func == "diff" {
+						} else if cons == "diff" {
 							r.Values[ridx] = w.Diff()
-						} else if func == "stddev" {
+						} else if cons == "stddev" {
 							r.Values[ridx] = w.Stdev()
-						} else if func == "count" {
+						} else if cons == "count" {
 							r.Values[ridx] = w.Count()
-						} else if func == "last" {
+						} else if cons == "last" {
 							r.Values[ridx] = w.Last()
-						} else if func == "median" {
+						} else if cons == "median" {
 							r.Values[ridx] = w.Median()
 						}
 					case "movingAverage":

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -80,6 +80,10 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		return nil, parser.ErrMissingArgument
 	}
 
+	if len(e.Args()) == 3 {
+		func := e.GetStringArg(2)
+	}
+
 	switch e.Args()[1].Type() {
 	case parser.EtConst:
 		// In this case, zipper does not request additional retrospective points,
@@ -155,6 +159,32 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			if ridx := i - offset; ridx >= 0 {
 				if helper.XFilesFactorValues(w.Data, xFilesFactor) {
 					switch e.Target() {
+					case "movingWindow":
+						if func == "average" || func == "avg" {
+							r.Values[ridx] = w.Mean()
+						} else if func == "avg_zero" {
+							r.Values[ridx] = w.MeanZero()
+						} else if func == "sum" {
+							r.Values[ridx] = w.Sum()
+						} else if func == "min" {
+							r.Values[ridx] = w.Min()
+						} else if func == "max" {
+							r.Values[ridx] = w.Max()
+						} else if func == "multiply" {
+							r.Values[ridx] = w.Multiply()
+						} else if func == "range" {
+							r.Values[ridx] = w.Range()
+						} else if func == "diff" {
+							r.Values[ridx] = w.Diff()
+						} else if func == "stddev" {
+							r.Values[ridx] = w.Stdev()
+						} else if func == "count" {
+							r.Values[ridx] = w.Count()
+						} else if func == "last" {
+							r.Values[ridx] = w.Last()
+						} else if func == "median" {
+							r.Values[ridx] = w.Median()
+						}
 					case "movingAverage":
 						r.Values[ridx] = w.Mean()
 					case "movingSum":
@@ -184,6 +214,43 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
 func (f *moving) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
+		"movingWindow": {
+			Description: "Graphs a moving window function of a metric (or metrics) over a fixed number of past points, or a time interval.\n\nTakes one metric or a wildcard seriesList followed by a number N of datapoints\nor a quoted string with a length of time like '1hour' or '5min' (See ``from /\nuntil`` in the render\\_api_ for examples of time formats), and an xFilesFactor value to specify\nhow many points in the window must be non-null for the output to be considered valid. Graphs the\nsum of the preceeding datapoints for each point on the graph.\n\nExample:\n\n.. code-block:: none\n\n  &target=movingWindow(Server.instance01.threads.busy,10)\n  &target=movingWindow(Server.instance*.threads.idle,'5min','median',0.5)",
+			Function:    "movingWindow(seriesList, windowSize, func='average', xFilesFactor=None)",
+			Group:       "Calculate",
+			Module:      "graphite.render.functions",
+			Name:        "movingWindow",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "windowSize",
+					Required: true,
+					Suggestions: types.NewSuggestions(
+						5,
+						7,
+						10,
+						"1min",
+						"5min",
+						"10min",
+						"30min",
+						"1hour",
+					),
+					Type: types.IntOrInterval,
+				},
+				{
+					Name: "func",
+					Type: types.AggFunc,
+				},
+				{
+					Name: "xFilesFactor",
+					Type: types.Float,
+				},
+			},
+		},
 		"movingAverage": {
 			Description: "Graphs the moving average of a metric (or metrics) over a fixed number of\npast points, or a time interval.\n\nTakes one metric or a wildcard seriesList followed by a number N of datapoints\nor a quoted string with a length of time like '1hour' or '5min' (See ``from /\nuntil`` in the render\\_api_ for examples of time formats), and an xFilesFactor value to specify\nhow many points in the window must be non-null for the output to be considered valid. Graphs the\naverage of the preceeding datapoints for each point on the graph.\n\nExample:\n\n.. code-block:: none\n\n  &target=movingAverage(Server.instance01.threads.busy,10)\n  &target=movingAverage(Server.instance*.threads.idle,'5min')",
 			Function:    "movingAverage(seriesList, windowSize, xFilesFactor=None)",

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 	logger := zapwriter.Logger("functionInit").With(zap.String("function", "moving"))
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &moving{}
-	functions := []string{"movingAverage", "movingMin", "movingMax", "movingSum"}
+	functions := []string{"movingAverage", "movingMin", "movingMax", "movingSum", "movingWindow"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
@@ -73,6 +73,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 	var scaleByStep bool
 
 	var argstr string
+	var cons string
 
 	var xFilesFactor float64
 
@@ -81,7 +82,10 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 	}
 
 	if len(e.Args()) == 3 {
-		func := e.GetStringArg(2)
+		cons, err = e.GetStringArgDefault(2, "average")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	switch e.Args()[1].Type() {

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -27,6 +27,13 @@ func TestMoving(t *testing.T) {
 
 	tests := []th.EvalTestItem{
 		{
+			"movingWindow(metric1,average,'3sec')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,"3sec")`, []float64{2, 2, 2}, 1, 0)}, // StartTime = from
+		},
+		{
 			"movingAverage(metric1,'3sec')",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -27,11 +27,32 @@ func TestMoving(t *testing.T) {
 
 	tests := []th.EvalTestItem{
 		{
-			"movingWindow(metric1,average,'3sec')",
+			"movingWindow(metric1,'3sec','average')",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,"3sec")`, []float64{2, 2, 2}, 1, 0)}, // StartTime = from
+			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{2, 2, 2}, 1, 0)}, // StartTime = from
+		},
+		{
+			"movingWindow(metric1,'3sec','avg_zero')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{1, 1, 0.3333333333333333}, 1, 0)}, // StartTime = from
+		},
+		{
+			"movingWindow(metric1,'3sec','count')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, math.NaN(), 1, math.NaN(), 3}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{2, 2, 1}, 1, 0)}, // StartTime = from
+		},
+		{
+			"movingWindow(metric1,'3sec','diff')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{-4, -5, -3}, 1, 0)}, // StartTime = from
 		},
 		{
 			"movingAverage(metric1,'3sec')",

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -52,7 +52,7 @@ func TestMoving(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{-4, -5, -3}, 1, 0)}, // StartTime = from
+			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{-4, -1, 3}, 1, 0)}, // StartTime = from
 		},
 		{
 			"movingWindow(metric1,'3sec','range')",
@@ -73,7 +73,7 @@ func TestMoving(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{3, 3, 3}, 1, 0)}, // StartTime = from
+			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{3, 0, math.NaN()}, 1, 0)}, // StartTime = from
 		},
 		{
 			"movingAverage(metric1,'3sec')",

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -55,6 +55,27 @@ func TestMoving(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{-4, -5, -3}, 1, 0)}, // StartTime = from
 		},
 		{
+			"movingWindow(metric1,'3sec','range')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{2, 3, 3}, 1, 0)}, // StartTime = from
+		},
+		{
+			"movingWindow(metric1,'3sec','stddev')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 0, 3, math.NaN(), 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{0.8164965809277259, 1.247219128924647, 1.5}, 1, 0)}, // StartTime = from
+		},
+		{
+			"movingWindow(metric1,'3sec','last')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 0, math.NaN(), 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingWindow(metric1,"3sec")`, []float64{3, 3, 3}, 1, 0)}, // StartTime = from
+		},
+		{
 			"movingAverage(metric1,'3sec')",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 1, 2, 3}, 1, now32)},

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/grafana/carbonapi/expr/consolidations"
 	"math"
 )
 
@@ -13,12 +14,13 @@ import (
 
 // Windowed is a struct to compute simple windowed stats
 type Windowed struct {
-	Data   []float64
-	head   int
-	length int
-	sum    float64
-	sumsq  float64
-	nans   int
+	Data     []float64
+	head     int
+	length   int
+	sum      float64
+	sumsq    float64
+	multiply float64
+	nans     int
 }
 
 // Push pushes data
@@ -47,6 +49,7 @@ func (w *Windowed) Push(n float64) {
 	if !math.IsNaN(n) {
 		w.sum += n
 		w.sumsq += (n * n)
+		w.multiply *= n
 	} else {
 		w.nans++
 	}
@@ -83,8 +86,19 @@ func (w *Windowed) Sum() float64 {
 	return w.sum
 }
 
+func (w *Windowed) Multiply() float64 {
+	return w.multiply
+}
+
 // Mean returns mean value of data
 func (w *Windowed) Mean() float64 { return w.sum / float64(w.Len()) }
+
+// MeanZero returns mean value of data, with NaN values replaced with 0
+func (w *Windowed) MeanZero() float64 { return w.sum / float64(len(w.Data)) }
+
+func (w *Windowed) Median() float64 {
+	return consolidations.Percentile(w.Data, 50, true)
+}
 
 // Max returns max(values)
 func (w *Windowed) Max() float64 {
@@ -106,4 +120,39 @@ func (w *Windowed) Min() float64 {
 		}
 	}
 	return rv
+}
+
+// Count returns number of non-NaN points
+func (w *Windowed) Count() float64 {
+	return w.Len()
+}
+
+// Diff subtracts series 2 through n from series 1
+func (w *Windowed) Diff() float64 {
+	rv = w.Data[0]
+	for _, f := range w.Data[1:] {
+		total++
+		rv -= f
+	}
+	return rv
+}
+
+func (w *Windowed) Range() float64 {
+	vMax := math.Inf(-1)
+	vMin := math.Inf(1)
+	for _, f := range w.Data {
+		total++
+		if f > vMax {
+			vMax = f
+		}
+		if f < vMin {
+			vMin = f
+		}
+	}
+	return vMax - vMin
+}
+
+// Last returns the last data point
+func (w *Windowed) Last() float64 {
+	return w.Data[len(w.Data)-1]
 }

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -125,15 +125,12 @@ func (w *Windowed) Min() float64 {
 
 // Count returns number of non-NaN points
 func (w *Windowed) Count() float64 {
-	fmt.Println("w.Data: ", w.Data)
-	fmt.Println("Returning count of : ", w.Len())
 	return float64(w.Len())
 }
 
 // Diff subtracts series 2 through n from series 1
 func (w *Windowed) Diff() float64 {
 	rv := w.Data[0]
-	fmt.Println("w.Data: ", w.Data)
 	for _, f := range w.Data[1:] {
 		if !math.IsNaN(f) {
 			rv -= f

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"github.com/grafana/carbonapi/expr/consolidations"
 	"math"
 )

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"github.com/grafana/carbonapi/expr/consolidations"
 	"math"
 )
@@ -124,14 +125,19 @@ func (w *Windowed) Min() float64 {
 
 // Count returns number of non-NaN points
 func (w *Windowed) Count() float64 {
+	fmt.Println("w.Data: ", w.Data)
+	fmt.Println("Returning count of : ", w.Len())
 	return float64(w.Len())
 }
 
 // Diff subtracts series 2 through n from series 1
 func (w *Windowed) Diff() float64 {
 	rv := w.Data[0]
+	fmt.Println("w.Data: ", w.Data)
 	for _, f := range w.Data[1:] {
-		rv -= f
+		if !math.IsNaN(f) {
+			rv -= f
+		}
 	}
 	return rv
 }
@@ -140,7 +146,6 @@ func (w *Windowed) Range() float64 {
 	vMax := math.Inf(-1)
 	vMin := math.Inf(1)
 	for _, f := range w.Data {
-		total++
 		if f > vMax {
 			vMax = f
 		}

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -124,14 +124,13 @@ func (w *Windowed) Min() float64 {
 
 // Count returns number of non-NaN points
 func (w *Windowed) Count() float64 {
-	return w.Len()
+	return float64(w.Len())
 }
 
 // Diff subtracts series 2 through n from series 1
 func (w *Windowed) Diff() float64 {
-	rv = w.Data[0]
+	rv := w.Data[0]
 	for _, f := range w.Data[1:] {
-		total++
 		rv -= f
 	}
 	return rv


### PR DESCRIPTION
This PR adds support for the Graphite web movingWindow() function.

The movingWindow() function is defined as:

```
movingWindow(seriesList, windowSize, func='average', xFilesFactor=None)
Graphs a moving window function of a metric (or metrics) over a fixed number of past points, or a time interval.

Takes one metric or a wildcard seriesList, a number N of datapoints or a quoted string with a length of time like ‘1hour’ or ‘5min’ (See from / until in the [Render API](https://graphite.readthedocs.io/en/latest/render_api.html) for examples of time formats), a function to apply to the points in the window to produce the output, and an xFilesFactor value to specify how many points in the window must be non-null for the output to be considered valid. Graphs the output of the function for the preceeding datapoints for each point on the graph.

Example:

&target=movingWindow(Server.instance01.threads.busy,10)
&target=movingWindow(Server.instance*.threads.idle,'5min','median',0.5)
```