### PR TITLE
Add support for Graphite web holtWintersConfidenceArea() function

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,7 @@ jobs:
       matrix:
         go:
           - ^1.18
-          # FIXME https://github.com/grafana/carbonapi/issues/70
-          # - ^1.19
+          - ^1.19
           - ^1
     steps:
 

--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -238,7 +238,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 		ApiMetrics.RequestCacheMisses.Add(1)
 	}
 
-	if from32 == until32 {
+	if from32 >= until32 {
 		setError(w, accessLogDetails, "Invalid or empty time range", http.StatusBadRequest, uid.String())
 		logAsError = true
 		return

--- a/cmd/mockbackend/testcases/pr560/pr560.yaml
+++ b/cmd/mockbackend/testcases/pr560/pr560.yaml
@@ -31,13 +31,6 @@ test:
             - endpoint: "http://127.0.0.1:8081"
               delay: 1
               type: "GET"
-              URL: "/render?target=constantLine('2222')"
-              expectedResponse:
-                  httpCode: 400
-                  contentType: "text/plain; charset=utf-8"
-            - endpoint: "http://127.0.0.1:8081"
-              delay: 1
-              type: "GET"
               URL: "/render?target=polyfit(a.b.c.d.e, 2, '12dd')"
               expectedResponse:
                   httpCode: 400

--- a/expr/consolidations/consolidations.go
+++ b/expr/consolidations/consolidations.go
@@ -426,9 +426,7 @@ func AggDiff(v []float64) float64 {
 		}
 
 		for _, vv := range safeValues[1:] {
-			if !math.IsNaN(vv) {
-				res -= vv
-			}
+			res -= vv
 		}
 
 		return res

--- a/expr/consolidations/consolidations.go
+++ b/expr/consolidations/consolidations.go
@@ -412,7 +412,7 @@ func AggCount(v []float64) float64 {
 }
 
 func AggDiff(v []float64) float64 {
-	safeValues := make([]float64, 0)
+	safeValues := make([]float64, 0, len(v))
 	for _, vv := range v {
 		if !math.IsNaN(vv) {
 			safeValues = append(safeValues, vv)

--- a/expr/consolidations/consolidations.go
+++ b/expr/consolidations/consolidations.go
@@ -2,12 +2,17 @@ package consolidations
 
 import (
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/ansel1/merry"
 
 	"github.com/wangjohn/quickselect"
 	"gonum.org/v1/gonum/mat"
 )
+
+var ErrInvalidConsolidationFunc = merry.New("Invalid Consolidation Function")
 
 // ConsolidationToFunc contains a map of graphite-compatible consolidation functions definitions to actual functions that can do aggregation
 // TODO(civil): take into account xFilesFactor
@@ -34,6 +39,18 @@ var ConsolidationToFunc = map[string]func([]float64) float64{
 }
 
 var AvailableSummarizers = []string{"sum", "total", "avg", "average", "avg_zero", "max", "min", "last", "current", "range", "rangeOf", "median", "multiply", "diff", "count", "stddev"}
+
+func CheckValidConsolidationFunc(functionName string) error {
+	if _, ok := ConsolidationToFunc[functionName]; ok {
+		return nil
+	} else {
+		// Check if this is a p50 - p99.9 consolidation
+		if match, _ := regexp.MatchString("p([0-9]*[.])?[0-9]+", functionName); match {
+			return nil
+		}
+	}
+	return ErrInvalidConsolidationFunc.WithMessage("invalid consolidation " + functionName)
+}
 
 // AvgValue returns average of list of values
 func AvgValue(f64s []float64) float64 {
@@ -222,12 +239,25 @@ func SummarizeValues(f string, values []float64, XFilesFactor float32) float64 {
 	case "stddev":
 		rv = math.Sqrt(VarianceValue(values))
 		total = notNans(values)
+	case "first":
+		if len(values) > 0 {
+			rv = values[0]
+		} else {
+			rv = math.NaN()
+		}
+		total = notNans(values)
 	default:
-		f = strings.Split(f, "p")[1]
-		percent, err := strconv.ParseFloat(f, 64)
-		if err == nil {
-			total = notNans(values)
-			rv = Percentile(values, percent, true)
+		// This processes function percentile functions such as p50 or p99.9.
+		// If a function name is passed in that does not match that format,
+		// it should be ignored
+		fn := strings.Split(f, "p")
+		if len(fn) > 1 {
+			f = fn[1]
+			percent, err := strconv.ParseFloat(f, 64)
+			if err == nil {
+				total = notNans(values)
+				rv = Percentile(values, percent, true)
+			}
 		}
 	}
 

--- a/expr/consolidations/consolidations_test.go
+++ b/expr/consolidations/consolidations_test.go
@@ -3,6 +3,8 @@ package consolidations
 import (
 	"math"
 	"testing"
+
+	"github.com/ansel1/merry"
 )
 
 func TestSummarizeValues(t *testing.T) {
@@ -133,6 +135,44 @@ func TestSummarizeValues(t *testing.T) {
 			actual := SummarizeValues(tt.function, tt.values, tt.xFilesFactor)
 			if math.Abs(actual-tt.expected) > epsilon {
 				t.Errorf("actual %v, expected %v", actual, tt.expected)
+			}
+		})
+	}
+
+}
+
+func TestCheckValidConsolidationFunc(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedResult error
+	}{
+		{
+			name:           "sum",
+			expectedResult: nil,
+		},
+		{
+			name:           "avg",
+			expectedResult: nil,
+		},
+		{
+			name:           "p50",
+			expectedResult: nil,
+		},
+		{
+			name:           "p99.9",
+			expectedResult: nil,
+		},
+		{
+			name:           "test",
+			expectedResult: ErrInvalidConsolidationFunc,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckValidConsolidationFunc(tt.name)
+			if result != nil && !merry.Is(result, tt.expectedResult) {
+				t.Errorf("actual %v, expected %v", result, tt.expectedResult)
 			}
 		})
 	}

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -40,11 +40,6 @@ func TestAverageSeries(t *testing.T) {
 		},
 		{
 			`aggregate(metric[123], "avg")`,
-			map[parser.MetricRequest][]*types.MetricData{},
-			[]*types.MetricData{},
-		},
-		{
-			`aggregate(metric[123], "avg")`,
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric[123]", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
@@ -210,6 +205,42 @@ func TestAverageSeries(t *testing.T) {
 			},
 			[]*types.MetricData{types.MakeMetricData("totalSeries(metric[123])",
 				[]float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "avg", 0.7)`, // Test with xFilesFactor
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, math.NaN(), 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("avgSeries(metric[123])",
+				[]float64{2, math.NaN(), 3, math.NaN(), 5, math.NaN()}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "sum", 0.5)`, // Test with xFilesFactor
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, math.NaN()}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("sumSeries(metric[123])",
+				[]float64{6, math.NaN(), 9, 8, 15, math.NaN()}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "max", 0.3)`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, math.NaN(), 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("maxSeries(metric[123])",
+				[]float64{3, math.NaN(), 4, 5, 6, 6}, 1, now32)},
 		},
 		{
 			`stddevSeries(metric[123])`,

--- a/expr/functions/aggregateSeriesLists/function_test.go
+++ b/expr/functions/aggregateSeriesLists/function_test.go
@@ -40,81 +40,94 @@ var (
 func TestFunction(t *testing.T) {
 	tests := []th.EvalTestItem{
 		{
-			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\",-1)",
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"mining.*.shipped", 0, 1}:   shipped,
 				{"mining.*.extracted", 0, 1}: extracted,
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\",-1)", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\",-1)", []float64{0.0, 0.0, -1.0, 2.0, 0.0, 0.0, -8.0, 13.0, 0.0, 0.0, -55.0, 89.0, 0.0, 0.0, -377.0}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\",-1)", []float64{math.NaN(), 5.65, 8.0, -4.5, 6.0, 6.7, 4.0, -2.95, 2.0, 10.111, 0.0, -6.565, math.NaN(), 5.575, -4.0, -10.585, math.NaN(), 18.19, -8.0, -14.605, -10.0}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\",-1)", []float64{5.1805, math.NaN(), 2.718, 6.022, 4.607, -1.234, 0.2330000000000001, -5.8839999999999995, 2.067, 0.7519999999999998, 0.128, 7.2335}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\")", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\")", []float64{0.0, 0.0, -1.0, 2.0, 0.0, 0.0, -8.0, 13.0, 0.0, 0.0, -55.0, 89.0, 0.0, 0.0, -377.0}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\")", []float64{math.NaN(), 5.65, 8.0, -4.5, 6.0, 6.7, 4.0, -2.95, 2.0, 10.111, 0.0, -6.565, math.NaN(), 5.575, -4.0, -10.585, math.NaN(), 18.19, -8.0, -14.605, -10.0}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\")", []float64{5.1805, math.NaN(), 2.718, 6.022, 4.607, -1.234, 0.2330000000000001, -5.8839999999999995, 2.067, 0.7519999999999998, 0.128, 7.2335}, 1, now),
 			},
 		},
 		{
-			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\",-1)",
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"mining.*.shipped", 0, 1}:   shipped,
 				{"mining.*.extracted", 0, 1}: extracted,
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\",-1)", []float64{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\",-1)", []float64{0, 0, -2, 4, 0, 0, -16, 26, 0, 0, -110, 178, 0, 0, -754}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\",-1)", []float64{math.NaN(), 11.3, 8, -4.5, 6, 6.7, 4, -5.9, 2, 10.111, 0, -13.13, math.NaN(), 11.15, -4, -21.17, math.NaN(), 18.19, -8, -29.21, -10}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\",-1)", []float64{10.361, math.NaN(), 5.436, 6.022, 9.214, -1.234, 0.4660000000000002, -11.767999999999999, 2.067, 1.5039999999999996, 0.128, 14.467}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\")", []float64{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\")", []float64{0, 0, -2, 4, 0, 0, -16, 26, 0, 0, -110, 178, 0, 0, -754}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\")", []float64{math.NaN(), 11.3, 8, -4.5, 6, 6.7, 4, -5.9, 2, 10.111, 0, -13.13, math.NaN(), 11.15, -4, -21.17, math.NaN(), 18.19, -8, -29.21, -10}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\")", []float64{10.361, math.NaN(), 5.436, 6.022, 9.214, -1.234, 0.4660000000000002, -11.767999999999999, 2.067, 1.5039999999999996, 0.128, 14.467}, 1, now),
 			},
 		},
 		{
-			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\",-1)",
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"mining.*.shipped", 0, 1}:   shipped,
 				{"mining.*.extracted", 0, 1}: extracted,
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\",-1)", []float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\",-1)", []float64{0, -2, 0, 0, 6, -10, 0, 0, 42, -68, 0, 0, 288, -466, 0}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\",-1)", []float64{math.NaN(), -6.7, 8, -4.5, 6, 6.7, 4, -11.9, 2, 10.111, 0, -11.13, math.NaN(), 17.15, -4, -11.170000000000002, math.NaN(), 18.19, -8, -11.21, -10}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\",-1)", []float64{-4.079, math.NaN(), 0.0, 6.022, 4.134, -1.234, 12.786000000000001, 14.972, 2.067, 17.043999999999997, 0.128, -3.357000000000001}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\")", []float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\")", []float64{0, -2, 0, 0, 6, -10, 0, 0, 42, -68, 0, 0, 288, -466, 0}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\")", []float64{math.NaN(), -6.7, 8, -4.5, 6, 6.7, 4, -11.9, 2, 10.111, 0, -11.13, math.NaN(), 17.15, -4, -11.170000000000002, math.NaN(), 18.19, -8, -11.21, -10}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\")", []float64{-4.079, math.NaN(), 0.0, 6.022, 4.134, -1.234, 12.786000000000001, 14.972, 2.067, 17.043999999999997, 0.128, -3.357000000000001}, 1, now),
 			},
 		},
 		{
-			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\",-1)",
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"mining.*.shipped", 0, 1}:   shipped,
 				{"mining.*.extracted", 0, 1}: extracted,
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\",-1)", []float64{1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225, 256, 289, 324, 361, 400}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\",-1)", []float64{0, -1, 1, 4, -9, -25, 64, 169, -441, -1156, 3025, 7921, -20736, -54289, 142129}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\",-1)", []float64{math.NaN(), 20.7, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), -26.7, math.NaN(), math.NaN(), math.NaN(), 12.13, math.NaN(), -42.45, math.NaN(), 80.85, math.NaN(), math.NaN(), math.NaN(), 181.89, math.NaN()}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\",-1)", []float64{22.67802, math.NaN(), 7.387524, math.NaN(), 16.95196, math.NaN(), -40.81616, -21.41874, math.NaN(), -72.05897999999999, math.NaN(), 49.50616}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\")", []float64{1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225, 256, 289, 324, 361, 400}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\")", []float64{0, -1, 1, 4, -9, -25, 64, 169, -441, -1156, 3025, 7921, -20736, -54289, 142129}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\")", []float64{math.NaN(), 20.7, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), -26.7, math.NaN(), math.NaN(), math.NaN(), 12.13, math.NaN(), -42.45, math.NaN(), 80.85, math.NaN(), math.NaN(), math.NaN(), 181.89, math.NaN()}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\")", []float64{22.67802, math.NaN(), 7.387524, math.NaN(), 16.95196, math.NaN(), -40.81616, -21.41874, math.NaN(), -72.05897999999999, math.NaN(), 49.50616}, 1, now),
 			},
 		},
 		{
-			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\",-1)",
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"mining.*.shipped", 0, 1}:   shipped,
 				{"mining.*.extracted", 0, 1}: extracted,
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\",-1)", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\",-1)", []float64{0, 1, -1, 2, 3, 5, -8, 13, 21, 34, -55, 89, 144, 233, -377}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\",-1)", []float64{math.NaN(), 9, 8, -4.5, 6, 6.7, 4, 3, 2, 10.111, 0, -1, math.NaN(), 14.15, -4, -5, math.NaN(), 18.19, -8, -9, -10}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\",-1)", []float64{7.22, math.NaN(), 2.718, 6.022, 6.674, -1.234, 6.626, 1.602, 2.067, 9.274, 0.128, 8.912}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\")", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\")", []float64{0, 1, -1, 2, 3, 5, -8, 13, 21, 34, -55, 89, 144, 233, -377}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\")", []float64{math.NaN(), 9, 8, -4.5, 6, 6.7, 4, 3, 2, 10.111, 0, -1, math.NaN(), 14.15, -4, -5, math.NaN(), 18.19, -8, -9, -10}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\")", []float64{7.22, math.NaN(), 2.718, 6.022, 6.674, -1.234, 6.626, 1.602, 2.067, 9.274, 0.128, 8.912}, 1, now),
 			},
 		},
 		{
-			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\",-1)",
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"mining.*.shipped", 0, 1}:   shipped,
 				{"mining.*.extracted", 0, 1}: extracted,
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\",-1)", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\",-1)", []float64{0, -1, -1, 2, -3, -5, -8, 13, -21, -34, -55, 89, -144, -233, -377}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\",-1)", []float64{math.NaN(), 2.3, 8, -4.5, 6, 6.7, 4, -8.9, 2, 10.111, 0, -12.13, math.NaN(), -3, -4, -16.17, math.NaN(), 18.19, -8, -20.21, -10}, 1, now),
-				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\",-1)", []float64{3.141, math.NaN(), 2.718, 6.022, 2.54, -1.234, -6.16, -13.37, 2.067, -7.77, 0.128, 5.555}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\")", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\")", []float64{0, -1, -1, 2, -3, -5, -8, 13, -21, -34, -55, 89, -144, -233, -377}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\")", []float64{math.NaN(), 2.3, 8, -4.5, 6, 6.7, 4, -8.9, 2, 10.111, 0, -12.13, math.NaN(), -3, -4, -16.17, math.NaN(), 18.19, -8, -20.21, -10}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\")", []float64{3.141, math.NaN(), 2.718, 6.022, 2.54, -1.234, -6.16, -13.37, 2.067, -7.77, 0.128, 5.555}, 1, now),
+			},
+		},
+		{
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\", 0.6)", // Test with xFilesFactor
+			map[parser.MetricRequest][]*types.MetricData{
+				{"mining.*.shipped", 0, 1}:   shipped,
+				{"mining.*.extracted", 0, 1}: extracted,
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\", 0.6)", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\", 0.6)", []float64{0.0, 0.0, -1.0, 2.0, 0.0, 0.0, -8.0, 13.0, 0.0, 0.0, -55.0, 89.0, 0.0, 0.0, -377.0}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\", 0.6)", []float64{math.NaN(), 5.65, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), -2.95, math.NaN(), math.NaN(), math.NaN(), -6.565, math.NaN(), 5.575, math.NaN(), -10.585, math.NaN(), math.NaN(), math.NaN(), -14.605, math.NaN()}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\", 0.6)", []float64{5.1805, math.NaN(), 2.718, math.NaN(), 4.607, math.NaN(), 0.2330000000000001, -5.8839999999999995, math.NaN(), 0.7519999999999998, math.NaN(), 7.2335}, 1, now),
 			},
 		},
 	}

--- a/expr/functions/aggregateWithWildcards/function.go
+++ b/expr/functions/aggregateWithWildcards/function.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-graphite/carbonapi/expr/consolidations"
 	"github.com/go-graphite/carbonapi/expr/helper"
-	"github.com/go-graphite/carbonapi/expr/helper/metric"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
@@ -66,7 +65,7 @@ func (f *aggregateWithWildcards) Do(ctx context.Context, e parser.Expr, from, un
 	nodeList := []string{}
 
 	for _, a := range args {
-		metric := metric.ExtractMetric(a.Name)
+		metric := types.ExtractNameTag(a.Name)
 		nodes := strings.Split(metric, ".")
 		var s []string
 		// Yes, this is O(n^2), but len(nodes) < 10 and len(fields) < 3

--- a/expr/functions/aliasByBase64/function.go
+++ b/expr/functions/aliasByBase64/function.go
@@ -46,8 +46,7 @@ func (f *aliasByBase64) Do(ctx context.Context, e parser.Expr, from, until int64
 		if withoutFieldArg {
 			decoded, err := base64.StdEncoding.DecodeString(a.Name)
 			if err == nil {
-				r = a.CopyLink()
-				r.Name = string(decoded)
+				r = a.CopyName(string(decoded))
 			} else {
 				r = a
 			}

--- a/expr/functions/aliasByMetric/function.go
+++ b/expr/functions/aliasByMetric/function.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
-	"github.com/go-graphite/carbonapi/expr/helper/metric"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
@@ -31,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 func (f *aliasByMetric) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	return helper.ForEachSeriesDo1(ctx, e, from, until, values, func(a *types.MetricData) *types.MetricData {
-		metric := metric.ExtractMetric(a.Name)
+		metric := types.ExtractNameTag(a.Name)
 		part := strings.Split(metric, ".")
 		name := part[len(part)-1]
 		ret := a.CopyName(name)

--- a/expr/functions/aliasByNode/function.go
+++ b/expr/functions/aliasByNode/function.go
@@ -40,7 +40,8 @@ func (f *aliasByNode) Do(ctx context.Context, e parser.Expr, from, until int64, 
 	results := make([]*types.MetricData, len(args))
 
 	for i, a := range args {
-		r := a.CopyName(helper.AggKey(a, nodesOrTags))
+		name := helper.AggKey(a, nodesOrTags)
+		r := a.CopyTag(name, map[string]string{"name": name})
 		results[i] = r
 	}
 

--- a/expr/functions/aliasByNode/function_test.go
+++ b/expr/functions/aliasByNode/function_test.go
@@ -131,15 +131,14 @@ func TestAliasByNode(t *testing.T) {
 			},
 			Want: []*types.MetricData{types.MakeMetricData("base.metric1", []float64{math.NaN(), 1, 1, 1, 1}, 1, now32)},
 		},
-		// FIXME: I don't think `metric1.foo==.bar.baz` is a valid metric name, that is making this test fail https://github.com/grafana/carbonapi/issues/68
-		// {
-		// 	Target: "aliasByNode(metric1.fo*.bar.baz,1,3)",
-		// 	M: map[parser.MetricRequest][]*types.MetricData{
-		// 		{Metric: "metric1.fo*.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo==.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
-		// 	},
-		// 	Want: []*types.MetricData{types.MakeMetricData("foo==.baz",
-		// 		[]float64{1, 2, 3, 4, 5}, 1, now32)},
-		// },
+		{
+			Target: "aliasByNode(metric1.fo*.bar.baz,1,3)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1.fo*.bar.baz", From: 0, Until: 1}: {types.MakeMetricData("metric1.foo==.bar.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData("foo==.baz",
+				[]float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
 		{
 			Target: `aliasByTags(*, 2, "baz", "foo", 1)`,
 			M: map[parser.MetricRequest][]*types.MetricData{

--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -780,18 +780,24 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 
 		results := make([]*types.MetricData, len(arg))
 
+		var dashLen float64
+		var dashLenStr string
+		if e.Target() == "dashed" {
+			dashLen, err := e.GetFloatArgDefault(1, 2.5)
+			if err != nil {
+				return nil, err
+			}
+			dashLenStr = strconv.FormatFloat(dashLen, 'g', -1, 64)
+		}
+
 		for i, a := range arg {
-			r := *a
+			r := a.CopyLink()
 			r.Name = e.Target() + "(" + a.Name + ")"
 
 			switch e.Target() {
 			case "dashed":
-				d, err := e.GetFloatArgDefault(1, 2.5)
-				if err != nil {
-					return nil, err
-				}
-				r.Dashed = d
-				r.Tags["dashed"] = strconv.FormatFloat(d, 'g', -1, 64)
+				r.Dashed = dashLen
+				r.Tags["dashed"] = dashLenStr
 			case "drawAsInfinite":
 				r.DrawAsInfinite = true
 				r.Tags["drawAsInfinite"] = "1"
@@ -800,7 +806,7 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 				r.Tags["secondYAxis"] = "1"
 			}
 
-			results[i] = &r
+			results[i] = r
 		}
 		return results, nil
 

--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -790,7 +791,7 @@ func EvalExprGraph(ctx context.Context, e parser.Expr, from, until int64, values
 					return nil, err
 				}
 				r.Dashed = d
-				r.Tags["dashed"] = fmt.Sprintf("%f", d)
+				r.Tags["dashed"] = strconv.FormatFloat(d, 'g', -1, 64)
 			case "drawAsInfinite":
 				r.DrawAsInfinite = true
 				r.Tags["drawAsInfinite"] = "1"

--- a/expr/functions/constantLine/function_test.go
+++ b/expr/functions/constantLine/function_test.go
@@ -28,6 +28,12 @@ func TestConstantLine(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("42.42",
 				[]float64{42.42, 42.42}, 1, 0)},
 		},
+		{
+			"constantLine('42.42')", // Verify string input can be parsed into int or float
+			map[parser.MetricRequest][]*types.MetricData{},
+			[]*types.MetricData{types.MakeMetricData("42.42",
+				[]float64{42.42, 42.42}, 1, 0)},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/functions/delay/function.go
+++ b/expr/functions/delay/function.go
@@ -2,7 +2,6 @@ package delay
 
 import (
 	"context"
-	"fmt"
 	"math"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -65,7 +64,7 @@ func (f *delay) Do(ctx context.Context, e parser.Expr, from, until int64, values
 
 		result := series.CopyName("delay(" + series.Name + "," + stepsStr + ")")
 		result.Values = newValues
-		result.Tags["delay"] = fmt.Sprintf("%d", steps)
+		result.Tags["delay"] = stepsStr
 
 		results[i] = result
 	}

--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -80,16 +80,6 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		return nil, errors.New("must be called with 2 series or a wildcard that matches exactly 2 series")
 	}
 
-	alignedSeries := helper.AlignSeries(types.CopyMetricDataSlice(append(numerators, denominator)))
-	numerators = alignedSeries[:len(numerators)]
-	denominator = alignedSeries[len(numerators)]
-
-	for _, numerator := range numerators {
-		if numerator.StepTime != denominator.StepTime {
-			return nil, fmt.Errorf("series %s must have the same length as %s", numerator.Name, denominator.Name)
-		}
-	}
-
 	for _, numerator := range numerators {
 		var name string
 		if useMetricNames {
@@ -97,11 +87,13 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		} else {
 			name = "divideSeries(" + e.RawArgs() + ")"
 		}
+
+		numerator, denominator = helper.ConsolidateSeriesByStep(numerator, denominator)
+
 		r := numerator.CopyTag(name, numerator.Tags)
 		r.Values = make([]float64, len(numerator.Values))
 
 		for i, v := range numerator.Values {
-
 			// math.IsNaN(v) || math.IsNaN(denominator.Values[i]) covered by nature of math.NaN
 			if denominator.Values[i] == 0 {
 				r.Values[i] = math.NaN()

--- a/expr/functions/divideSeries/function_test.go
+++ b/expr/functions/divideSeries/function_test.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func TestDivideSeriesMultiReturn(t *testing.T) {
-	now32 := int64(time.Now().Unix())
+	now32 := time.Now().Unix()
 
 	tests := []th.MultiReturnEvalTestItem{
 		{
@@ -57,7 +57,7 @@ func TestDivideSeriesMultiReturn(t *testing.T) {
 }
 
 func TestDivideSeries(t *testing.T) {
-	now32 := int64(time.Now().Unix())
+	now32 := time.Now().Unix()
 
 	tests := []th.EvalTestItem{
 		{
@@ -99,39 +99,57 @@ func TestDivideSeries(t *testing.T) {
 }
 
 func TestDivideSeriesAligned(t *testing.T) {
-	now32 := int64(time.Now().Unix())
+	startTime := int64(0)
 
-	tests := []th.EvalTestItem{
+	tests := []th.EvalTestItemWithRange{
 		{
 			"divideSeries(metric1,metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {
-					types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, now32),
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, startTime),
 				},
 				{"metric2", 0, 1}: {
-					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, startTime),
 				},
 			},
 			[]*types.MetricData{types.MakeMetricData("divideSeries(metric1,metric2)",
-				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, math.NaN()}, 1, now32)},
+				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, math.NaN()}, 1, startTime)},
+			startTime,
+			startTime + 1,
 		},
 		{
 			"divideSeries(metric[23])",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric[23]", 0, 1}: {
-					types.MakeMetricData("metric2", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, now32),
-					types.MakeMetricData("metric3", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, startTime),
+					types.MakeMetricData("metric3", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, startTime),
 				},
 			},
 			[]*types.MetricData{types.MakeMetricData("divideSeries(metric[23])",
-				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, math.NaN()}, 1, now32).SetNameTag("metric2")},
+				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, math.NaN()}, 1, startTime).SetNameTag("metric2")},
+			startTime,
+			startTime + 1,
+		},
+		{
+			"divideSeries(metric3,metric4)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric3", 0, 1}: {
+					types.MakeMetricData("metric3", []float64{1, math.NaN(), math.NaN(), 3, 4, 8, 2, math.NaN(), 3, math.NaN(), 0, 6}, 5, startTime),
+				},
+				{"metric4", 0, 1}: {
+					types.MakeMetricData("metric4", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 10, startTime),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("divideSeries(metric3,metric4)",
+				[]float64{0.5, math.NaN(), 2, math.NaN(), math.NaN(), 0.5}, 10, startTime)},
+			startTime,
+			startTime + 1,
 		},
 	}
 
 	for _, tt := range tests {
-		testName := tt.Target
-		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+		t.Run(tt.Target, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
 		})
 	}
 }

--- a/expr/functions/exp/function.go
+++ b/expr/functions/exp/function.go
@@ -2,7 +2,6 @@ package exp
 
 import (
 	"context"
-	"fmt"
 	"math"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -38,7 +37,7 @@ func (f *exp) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 
 	for _, a := range args {
 		r := a.CopyLink()
-		r.Name = fmt.Sprintf("exp(%s)", a.Name)
+		r.Name = "exp(" + a.Name + ")"
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["exp"] = "e"
 

--- a/expr/functions/exponentialMovingAverage/function.go
+++ b/expr/functions/exponentialMovingAverage/function.go
@@ -79,7 +79,7 @@ func (f *exponentialMovingAverage) Do(ctx context.Context, e parser.Expr, from, 
 
 	for _, a := range arg {
 		r := a.CopyLink()
-		r.Name = fmt.Sprintf("%s(%s,%s)", e.Target(), a.Name, argstr)
+		r.Name = e.Target() + "(" + a.Name + "," + argstr + ")"
 
 		var vals []float64
 

--- a/expr/functions/fallbackSeries/function.go
+++ b/expr/functions/fallbackSeries/function.go
@@ -33,6 +33,10 @@ func (f *fallbackSeries) Do(ctx context.Context, e parser.Expr, from, until int6
 		Takes a wildcard seriesList, and a second fallback metric.
 		If the wildcard does not match any series, draws the fallback metric.
 	*/
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingTimeseries
+	}
+
 	seriesList, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	fallback, errFallback := helper.GetSeriesArg(ctx, e.Arg(1), from, until, values)
 	if errFallback != nil && err != nil {

--- a/expr/functions/fallbackSeries/function_test.go
+++ b/expr/functions/fallbackSeries/function_test.go
@@ -74,3 +74,29 @@ func TestFallbackSeries(t *testing.T) {
 	}
 
 }
+
+func TestErrorMissingTimeSeriesFunction(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItemWithError{
+		{
+			"fallbackSeries(metric*)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					types.MakeMetricData("metricB", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					types.MakeMetricData("metricC", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+				},
+			},
+			nil,
+			parser.ErrMissingTimeseries,
+		},
+	}
+
+	for _, testCase := range tests {
+		testName := testCase.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithError(t, &testCase)
+		})
+	}
+}

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -46,6 +46,7 @@ import (
 	"github.com/go-graphite/carbonapi/expr/functions/highestLowest"
 	"github.com/go-graphite/carbonapi/expr/functions/hitcount"
 	"github.com/go-graphite/carbonapi/expr/functions/holtWintersAberration"
+	"github.com/go-graphite/carbonapi/expr/functions/holtWintersConfidenceArea"
 	"github.com/go-graphite/carbonapi/expr/functions/holtWintersConfidenceBands"
 	"github.com/go-graphite/carbonapi/expr/functions/holtWintersForecast"
 	"github.com/go-graphite/carbonapi/expr/functions/identity"
@@ -68,7 +69,6 @@ import (
 	"github.com/go-graphite/carbonapi/expr/functions/mapSeries"
 	"github.com/go-graphite/carbonapi/expr/functions/minMax"
 	"github.com/go-graphite/carbonapi/expr/functions/mostDeviant"
-	"github.com/go-graphite/carbonapi/expr/functions/moving"
 	"github.com/go-graphite/carbonapi/expr/functions/movingMedian"
 	"github.com/go-graphite/carbonapi/expr/functions/multiplySeriesWithWildcards"
 	"github.com/go-graphite/carbonapi/expr/functions/nPercentile"
@@ -170,6 +170,7 @@ func New(configs map[string]string) {
 		{name: "highestLowest", filename: "highestLowest", order: highestLowest.GetOrder(), f: highestLowest.New},
 		{name: "hitcount", filename: "hitcount", order: hitcount.GetOrder(), f: hitcount.New},
 		{name: "holtWintersAberration", filename: "holtWintersAberration", order: holtWintersAberration.GetOrder(), f: holtWintersAberration.New},
+		{name: "holtWintersConfidenceArea", filename: "holtWintersConfidenceArea", order: holtWintersConfidenceArea.GetOrder(), f: holtWintersConfidenceArea.New},
 		{name: "holtWintersConfidenceBands", filename: "holtWintersConfidenceBands", order: holtWintersConfidenceBands.GetOrder(), f: holtWintersConfidenceBands.New},
 		{name: "holtWintersForecast", filename: "holtWintersForecast", order: holtWintersForecast.GetOrder(), f: holtWintersForecast.New},
 		{name: "identity", filename: "identity", order: identity.GetOrder(), f: identity.New},
@@ -192,7 +193,6 @@ func New(configs map[string]string) {
 		{name: "mapSeries", filename: "mapSeries", order: mapSeries.GetOrder(), f: mapSeries.New},
 		{name: "minMax", filename: "minMax", order: minMax.GetOrder(), f: minMax.New},
 		{name: "mostDeviant", filename: "mostDeviant", order: mostDeviant.GetOrder(), f: mostDeviant.New},
-		{name: "moving", filename: "moving", order: moving.GetOrder(), f: moving.New},
 		{name: "movingMedian", filename: "movingMedian", order: movingMedian.GetOrder(), f: movingMedian.New},
 		{name: "multiplySeriesWithWildcards", filename: "multiplySeriesWithWildcards", order: multiplySeriesWithWildcards.GetOrder(), f: multiplySeriesWithWildcards.New},
 		{name: "nPercentile", filename: "nPercentile", order: nPercentile.GetOrder(), f: nPercentile.New},

--- a/expr/functions/groupByNode/function_test.go
+++ b/expr/functions/groupByNode/function_test.go
@@ -168,37 +168,36 @@ func TestGroupByNode(t *testing.T) {
 				"metric1.foo.bar1.bla.foo": {types.MakeMetricData("metric1.foo.bar1.bla.foo", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 		},
-		// FIXME: I don't think `..foo==.bar` is a valid metric name, that is making these tests fail https://github.com/grafana/carbonapi/issues/68
-		// {
-		// 	Target: "groupByNode(metric1.foo.*.*,2,\"sum\")",
-		// 	M: map[parser.MetricRequest][]*types.MetricData{
-		// 		mr: {
-		// 			types.MakeMetricData("metric1.foo.Ab1==.lag", []float64{1, 2, 3, 4, 5}, 1, now32),
-		// 			types.MakeMetricData("metric1.foo.bC2=.lag", []float64{6, 7, 8, 9, 10}, 1, now32),
-		// 			types.MakeMetricData("metric1.foo.Ab1==.lag", []float64{11, 12, 13, 14, 15}, 1, now32),
-		// 			types.MakeMetricData("metric1.foo.bC2=.lag=", []float64{7, 8, 9, 10, 11}, 1, now32),
-		// 		},
-		// 	},
-		// 	Name: "groupByNode_names_with_special_symbol_equal",
-		// 	Results: map[string][]*types.MetricData{
-		// 		"Ab1==": {types.MakeMetricData("Ab1==", []float64{12, 14, 16, 18, 20}, 1, now32)},
-		// 		"bC2=":  {types.MakeMetricData("bC2=", []float64{13, 15, 17, 19, 21}, 1, now32)},
-		// 	},
-		// },
-		// {
-		// 	Target: "groupByNode(metric1.foo.*.*,3,\"sum\")",
-		// 	M: map[parser.MetricRequest][]*types.MetricData{
-		// 		mr: {
-		// 			types.MakeMetricData("metric1.foo.Ab1==.lag;tag1=value1", []float64{1, 2, 3, 4, 5}, 1, now32),
-		// 			types.MakeMetricData("metric1.foo.Ab2.lag=;tag1=value1", []float64{1, 0, 3, 4, 5}, 1, now32),
-		// 		},
-		// 	},
-		// 	Name: "groupByNode_tagged_names_with_special_symbol_equal",
-		// 	Results: map[string][]*types.MetricData{
-		// 		"lag":  {types.MakeMetricData("lag", []float64{1, 2, 3, 4, 5}, 1, now32)},
-		// 		"lag=": {types.MakeMetricData("lag=", []float64{1, 0, 3, 4, 5}, 1, now32)},
-		// 	},
-		// },
+		{
+			Target: "groupByNode(metric1.foo.*.*,2,\"sum\")",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				mr: {
+					types.MakeMetricData("metric1.foo.Ab1==.lag", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric1.foo.bC2=.lag", []float64{6, 7, 8, 9, 10}, 1, now32),
+					types.MakeMetricData("metric1.foo.Ab1==.lag", []float64{11, 12, 13, 14, 15}, 1, now32),
+					types.MakeMetricData("metric1.foo.bC2=.lag=", []float64{7, 8, 9, 10, 11}, 1, now32),
+				},
+			},
+			Name: "groupByNode_names_with_special_symbol_equal",
+			Results: map[string][]*types.MetricData{
+				"Ab1==": {types.MakeMetricData("Ab1==", []float64{12, 14, 16, 18, 20}, 1, now32)},
+				"bC2=":  {types.MakeMetricData("bC2=", []float64{13, 15, 17, 19, 21}, 1, now32)},
+			},
+		},
+		{
+			Target: "groupByNode(metric1.foo.*.*,3,\"sum\")",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				mr: {
+					types.MakeMetricData("metric1.foo.Ab1==.lag;tag1=value1", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric1.foo.Ab2.lag=;tag1=value1", []float64{1, 0, 3, 4, 5}, 1, now32),
+				},
+			},
+			Name: "groupByNode_tagged_names_with_special_symbol_equal",
+			Results: map[string][]*types.MetricData{
+				"lag":  {types.MakeMetricData("lag", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				"lag=": {types.MakeMetricData("lag=", []float64{1, 0, 3, 4, 5}, 1, now32)},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/functions/holtWintersConfidenceArea/function.go
+++ b/expr/functions/holtWintersConfidenceArea/function.go
@@ -72,7 +72,7 @@ func (f *holtWintersConfidenceArea) Do(ctx context.Context, e parser.Expr, from,
 
 		upperVals := make([]float64, len(upperBand))
 
-		for i, v := range upperband {
+		for i, v := range upperBand {
 			upperVals[i] = v - lowerBand[i]
 		}
 

--- a/expr/functions/holtWintersConfidenceArea/function.go
+++ b/expr/functions/holtWintersConfidenceArea/function.go
@@ -22,7 +22,7 @@ func GetOrder() interfaces.Order {
 
 func New(configFile string) []interfaces.FunctionMetadata {
 	res := make([]interfaces.FunctionMetadata, 0)
-	f := &holtWintersConfidenceBands{}
+	f := &holtWintersConfidenceArea{}
 	functions := []string{"holtWintersConfidenceArea"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})

--- a/expr/functions/holtWintersConfidenceArea/function.go
+++ b/expr/functions/holtWintersConfidenceArea/function.go
@@ -64,11 +64,12 @@ func (f *holtWintersConfidenceArea) Do(ctx context.Context, e parser.Expr, from,
 				PathExpression:    fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
 			},
 			Tags: arg.Tags,
+			GraphOptions: types.GraphOptions{
+				Stacked:   true,
+				StackName: types.DefaultStackName,
+				Invisible: true,
+			},
 		}
-
-		lowerSeries.Stacked = true
-		lowerSeries.StackName = types.DefaultStackName
-		lowerSeries.Invisible = true
 
 		upperVals := make([]float64, len(upperBand))
 
@@ -88,11 +89,18 @@ func (f *holtWintersConfidenceArea) Do(ctx context.Context, e parser.Expr, from,
 				PathExpression:    fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
 			},
 			Tags: arg.Tags,
+			GraphOptions: types.GraphOptions{
+				Stacked:   true,
+				StackName: types.DefaultStackName,
+				Invisible: true,
+			},
 		}
 
-		upperSeries.Stacked = true
-		upperSeries.StackName = types.DefaultStackName
-		upperSeries.Invisible = true
+		vals := make([]float64, len(upperSeries.Values))
+		for i, v := range upperSeries.Values {
+			vals[i] = v - lowerSeries.Values[i]
+		}
+		upperSeries.Values = vals
 
 		results = append(results, &lowerSeries, &upperSeries)
 	}

--- a/expr/functions/holtWintersConfidenceArea/function.go
+++ b/expr/functions/holtWintersConfidenceArea/function.go
@@ -1,0 +1,134 @@
+package holtWintersConfidenceArea
+
+import (
+	"context"
+	"fmt"
+
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/holtwinters"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+)
+
+type holtWintersConfidenceArea struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &holtWintersConfidenceBands{}
+	functions := []string{"holtWintersConfidenceArea"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+func (f *holtWintersConfidenceArea) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, 7*86400)
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from-bootstrapInterval, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	delta, err := e.GetFloatNamedOrPosArgDefault("delta", 1, 3)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]*types.MetricData, 0, len(args)*2)
+	for _, arg := range args {
+		stepTime := arg.StepTime
+
+		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(arg.Values, stepTime, delta, bootstrapInterval/86400)
+
+		lowerSeries := types.MetricData{
+			FetchResponse: pb.FetchResponse{
+				Name:              fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
+				Values:            lowerBand,
+				StepTime:          arg.StepTime,
+				StartTime:         arg.StartTime + bootstrapInterval,
+				StopTime:          arg.StopTime,
+				ConsolidationFunc: arg.ConsolidationFunc,
+				XFilesFactor:      arg.XFilesFactor,
+				PathExpression:    fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
+			},
+			Tags: arg.Tags,
+		}
+
+		lowerSeries.Stacked = true
+		lowerSeries.StackName = types.DefaultStackName
+		lowerSeries.Invisible = true
+
+		upperVals := make([]float64, len(upperBand))
+
+		for i, v := range upperband {
+			upperVals[i] = v - lowerBand[i]
+		}
+
+		upperSeries := types.MetricData{
+			FetchResponse: pb.FetchResponse{
+				Name:              fmt.Sprintf("holtWintersConfidenceUpper(%s)", arg.Name),
+				Values:            upperVals,
+				StepTime:          arg.StepTime,
+				StartTime:         arg.StartTime + bootstrapInterval,
+				StopTime:          arg.StopTime,
+				ConsolidationFunc: arg.ConsolidationFunc,
+				XFilesFactor:      arg.XFilesFactor,
+				PathExpression:    fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
+			},
+			Tags: arg.Tags,
+		}
+
+		upperSeries.Stacked = true
+		upperSeries.StackName = types.DefaultStackName
+		upperSeries.Invisible = true
+
+		results = append(results, &lowerSeries, &upperSeries)
+	}
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *holtWintersConfidenceArea) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"holtWintersConfidenceArea": {
+			Description: "Performs a Holt-Winters forecast using the series as input data and plots\n the area between the upper and lower bands of the predicted forecast deviations.",
+			Function:    "holtWintersConfidenceArea(seriesList, delta=3, bootstrapInterval='7d')",
+			Group:       "Calculate",
+			Module:      "graphite.render.functions",
+			Name:        "holtWintersConfidenceArea",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Default: types.NewSuggestion(3),
+					Name:    "delta",
+					Type:    types.Integer,
+				},
+				{
+					Default: types.NewSuggestion("7d"),
+					Name:    "bootstrapInterval",
+					Suggestions: types.NewSuggestions(
+						"7d",
+						"30d",
+					),
+					Type: types.Interval,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/holtWintersConfidenceArea/function.go
+++ b/expr/functions/holtWintersConfidenceArea/function.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/holtwinters"
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
 	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
-	"github.com/grafana/carbonapi/expr/helper"
-	"github.com/grafana/carbonapi/expr/holtwinters"
-	"github.com/grafana/carbonapi/expr/interfaces"
-	"github.com/grafana/carbonapi/expr/types"
-	"github.com/grafana/carbonapi/pkg/parser"
 )
 
 type holtWintersConfidenceArea struct {

--- a/expr/functions/identity/function.go
+++ b/expr/functions/identity/function.go
@@ -2,7 +2,6 @@ package identity
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
@@ -46,7 +45,7 @@ func (f *identity) Do(ctx context.Context, e parser.Expr, from, until int64, val
 
 	p := types.MetricData{
 		FetchResponse: pb.FetchResponse{
-			Name:              fmt.Sprintf("identity(%s)", name),
+			Name:              "identity(" + name + ")",
 			StartTime:         from,
 			StopTime:          until,
 			StepTime:          step,

--- a/expr/functions/integralByInterval/function.go
+++ b/expr/functions/integralByInterval/function.go
@@ -2,7 +2,6 @@ package integralByInterval
 
 import (
 	"context"
-	"fmt"
 	"math"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -55,7 +54,7 @@ func (f *integralByInterval) Do(ctx context.Context, e parser.Expr, from, until 
 		current := 0.0
 		currentTime := arg.StartTime
 
-		name := fmt.Sprintf("integralByInterval(%s,'%s')", arg.Name, e.Args()[1].StringValue())
+		name := "integralByInterval(" + arg.Name + ",'" + e.Args()[1].StringValue() + "')"
 		result := arg.CopyLink()
 		result.Name = name
 		result.PathExpression = name

--- a/expr/functions/integralByInterval/function.go
+++ b/expr/functions/integralByInterval/function.go
@@ -54,7 +54,7 @@ func (f *integralByInterval) Do(ctx context.Context, e parser.Expr, from, until 
 		current := 0.0
 		currentTime := arg.StartTime
 
-		name := "integralByInterval(" + arg.Name + ",'" + e.Args()[1].StringValue() + "')"
+		name := "integralByInterval(" + arg.Name + ",'" + intervalString + "')"
 		result := arg.CopyLink()
 		result.Name = name
 		result.PathExpression = name

--- a/expr/functions/legendValue/function.go
+++ b/expr/functions/legendValue/function.go
@@ -48,6 +48,9 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int64, 
 		if method == "si" || method == "binary" {
 			system = method
 		} else {
+			if err := consolidations.CheckValidConsolidationFunc(method); err != nil {
+				return nil, err
+			}
 			methods = append(methods, method)
 		}
 	}

--- a/expr/functions/linearRegression/function.go
+++ b/expr/functions/linearRegression/function.go
@@ -2,8 +2,8 @@ package linearRegression
 
 import (
 	"context"
-	"fmt"
 	"math"
+	"strconv"
 
 	"github.com/go-graphite/carbonapi/expr/consolidations"
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -45,9 +45,9 @@ func (f *linearRegression) Do(ctx context.Context, e parser.Expr, from, until in
 	for _, a := range arg {
 		r := a.CopyLink()
 		if len(e.Args()) > 2 {
-			r.Name = fmt.Sprintf("linearRegression(%s,'%s','%s')", a.GetName(), e.Arg(1).StringValue(), e.Arg(2).StringValue())
+			r.Name = "linearRegression(" + a.GetName() + ",'" + e.Arg(1).StringValue() + "','" + e.Arg(2).StringValue() + "')"
 		} else if len(e.Args()) > 1 {
-			r.Name = fmt.Sprintf("linearRegression(%s,'%s')", a.GetName(), e.Arg(2).StringValue())
+			r.Name = "linearRegression(" + a.GetName() + ",'" + e.Arg(1).StringValue() + "')"
 		} else {
 			r.Name = "linearRegression(" + a.Name + ")"
 		}
@@ -88,7 +88,7 @@ func (f *linearRegression) Do(ctx context.Context, e parser.Expr, from, until in
 		for i := range r.Values {
 			r.Values[i] = consolidations.Poly(float64(i), c.RawMatrix().Data...)
 		}
-		r.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", a.GetStartTime(), a.GetStopTime())
+		r.Tags["linearRegressions"] = strconv.FormatInt(a.GetStartTime(), 10) + ", " + strconv.FormatInt(a.GetStopTime(), 10)
 
 		results = append(results, r)
 	}

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -144,9 +144,16 @@ func TestMovingXFilesFactor(t *testing.T) {
 		{
 			"movingAverage(metric1,4,0.6)",
 			map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8}, 1, now32)},
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, math.NaN(), 2, 4, math.NaN(), 4, 6, 8}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("movingAverage(metric1,4)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1.25, 1.5, 1.75, 2.5, 3.5, 4, 5}, 1, 0)}, // StartTime = from
+			[]*types.MetricData{types.MakeMetricData("movingAverage(metric1,4)", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 1.25, 1.3333333333333333, 1.6666666666666667, 2.666666666666666, math.NaN(), 3.3333333333333335, 4.666666666666667}, 1, 0)}, // StartTime = from
+		},
+		{
+			"movingMax(metric1,2,0.5)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, math.NaN(), math.NaN(), 0}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("movingMax(metric1,2)", []float64{math.NaN(), math.NaN(), 2, 3, 3, math.NaN()}, 1, 0)}, // StartTime = from
 		},
 	}
 

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -2,7 +2,6 @@ package movingMedian
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 
@@ -144,7 +143,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 				}
 			}
 		}
-		r.Tags["movingMedian"] = fmt.Sprintf("%d", windowSize)
+		r.Tags["movingMedian"] = argstr
 		result[n] = r
 	}
 	return result, nil

--- a/expr/functions/nPercentile/function.go
+++ b/expr/functions/nPercentile/function.go
@@ -2,7 +2,6 @@ package nPercentile
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 
@@ -46,9 +45,9 @@ func (f *nPercentile) Do(ctx context.Context, e parser.Expr, from, until int64, 
 	results := make([]*types.MetricData, len(arg))
 	for i, a := range arg {
 		r := a.CopyLink()
-		r.Name = fmt.Sprintf("nPercentile(%s,%s)", a.Name, percentStr)
+		r.Name = "nPercentile(" + a.Name + "," + percentStr + ")"
 		r.Values = make([]float64, len(a.Values))
-		r.Tags["nPercentile"] = fmt.Sprintf("%f", percent)
+		r.Tags["nPercentile"] = percentStr
 		var values []float64
 		for _, v := range a.Values {
 			if !math.IsNaN(v) {

--- a/expr/functions/offset/function.go
+++ b/expr/functions/offset/function.go
@@ -44,7 +44,7 @@ func (f *offset) Do(ctx context.Context, e parser.Expr, from, until int64, value
 
 	for i, a := range arg {
 		r := a.CopyLink()
-		r.Name = fmt.Sprintf("%s(%s,%s)", e.Target(), a.Name, factorStr)
+		r.Name = e.Target() + "(" + a.Name + "," + factorStr + ")"
 		r.Values = make([]float64, len(a.Values))
 		r.Tags[e.Target()] = fmt.Sprintf("%f", factor)
 

--- a/expr/functions/offset/function_test.go
+++ b/expr/functions/offset/function_test.go
@@ -35,7 +35,28 @@ func TestFunction(t *testing.T) {
 				[]float64{103, 104, 105, math.NaN(), 107, 108, 109, 110, 111}, 1, now32)},
 		},
 		{
+			"offset(metric1,'10')", // Verify string input can be parsed into int or float
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("offset(metric1,10)",
+				[]float64{103, 104, 105, math.NaN(), 107, 108, 109, 110, 111}, 1, now32)},
+		},
+		{
 			"add(metric*,-10)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32),
+					types.MakeMetricData("metric2", []float64{193, 194, 195, math.NaN(), 197, 198, 199, 200, 201}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("add(metric1,-10)", []float64{83, 84, 85, math.NaN(), 87, 88, 89, 90, 91}, 1, now32),
+				types.MakeMetricData("add(metric2,-10)", []float64{183, 184, 185, math.NaN(), 187, 188, 189, 190, 191}, 1, now32),
+			},
+		},
+		{
+			"add(metric*,'-10')", // Verify string input can be parsed into int or float
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric*", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{93, 94, 95, math.NaN(), 97, 98, 99, 100, 101}, 1, now32),

--- a/expr/functions/offsetToZero/function.go
+++ b/expr/functions/offsetToZero/function.go
@@ -2,8 +2,8 @@ package offsetToZero
 
 import (
 	"context"
-	"fmt"
 	"math"
+	"strconv"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
@@ -42,7 +42,7 @@ func (f *offsetToZero) Do(ctx context.Context, e parser.Expr, from, until int64,
 		for i, v := range a.Values {
 			r.Values[i] = v - minimum
 		}
-		r.Tags["offsetToZero"] = fmt.Sprintf("%f", minimum)
+		r.Tags["offsetToZero"] = strconv.FormatFloat(minimum, 'g', -1, 64)
 		return r
 	})
 }

--- a/expr/functions/pow/function.go
+++ b/expr/functions/pow/function.go
@@ -2,7 +2,6 @@ package pow
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 
@@ -45,9 +44,9 @@ func (f *pow) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 
 	for j, a := range arg {
 		r := a.CopyLink()
-		r.Name = fmt.Sprintf("pow(%s,%s)", a.Name, factorStr)
+		r.Name = "pow(" + a.Name + "," + factorStr + ")"
 		r.Values = make([]float64, len(a.Values))
-		r.Tags["pow"] = fmt.Sprintf("%f", factor)
+		r.Tags["pow"] = factorStr
 
 		for i, v := range a.Values {
 			if math.IsNaN(v) {

--- a/expr/functions/rangeOfSeries/function.go
+++ b/expr/functions/rangeOfSeries/function.go
@@ -38,7 +38,8 @@ func (f *rangeOfSeries) Do(ctx context.Context, e parser.Expr, from, until int64
 		return []*types.MetricData{}, nil
 	}
 
-	r := series[0].CopyName(e.Target() + "(" + e.RawArgs() + ")")
+	r := series[0].CopyLinkTags()
+	r.Name = e.Target() + "(" + e.RawArgs() + ")"
 	r.Values = make([]float64, len(series[0].Values))
 
 	commonTags := helper.GetCommonTags(series)

--- a/expr/functions/removeBelowSeries/function.go
+++ b/expr/functions/removeBelowSeries/function.go
@@ -2,8 +2,8 @@ package removeBelowSeries
 
 import (
 	"context"
-	"fmt"
 	"math"
+	"strconv"
 	"strings"
 
 	"github.com/go-graphite/carbonapi/expr/consolidations"
@@ -72,7 +72,7 @@ func (f *removeBelowSeries) Do(ctx context.Context, e parser.Expr, from, until i
 		r := a.CopyLink()
 		r.Name = e.Target() + "(" + a.Name + ", " + numberStr + ")"
 		r.Values = make([]float64, len(a.Values))
-		r.Tags["removeBelowSeries"] = fmt.Sprintf("%f", threshold)
+		r.Tags["removeBelowSeries"] = strconv.FormatFloat(threshold, 'f', -1, 64)
 
 		for i, v := range a.Values {
 			if math.IsNaN(v) || condition(v, threshold) {

--- a/expr/functions/removeBetweenPercentile/function.go
+++ b/expr/functions/removeBetweenPercentile/function.go
@@ -2,8 +2,8 @@ package removeBetweenPercentile
 
 import (
 	"context"
-	"fmt"
 	"math"
+	"strconv"
 
 	"github.com/go-graphite/carbonapi/expr/consolidations"
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -67,9 +67,10 @@ func (f *removeBetweenPercentile) Do(ctx context.Context, e parser.Expr, from, u
 		}
 	}
 
+	numberStr := strconv.FormatFloat(number, 'f', -1, 64)
 	for i, a := range args {
 		r := a.CopyLink()
-		r.Name = fmt.Sprintf("%s(%s, %g)", e.Target(), a.Name, number)
+		r.Name = e.Target() + "(" + a.Name + ", " + numberStr + ")"
 
 		for _, v := range a.Values {
 			if !(v > lowerThresholds[i] && v < higherThresholds[i]) {

--- a/expr/functions/removeEmptySeries/function.go
+++ b/expr/functions/removeEmptySeries/function.go
@@ -37,6 +37,9 @@ func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until i
 	if err != nil {
 		return nil, err
 	}
+	if len(args) == 0 {
+		return []*types.MetricData{}, nil
+	}
 
 	if len(e.Args()) == 2 {
 		xFilesFactor, err = e.GetFloatArgDefault(1, float64(args[0].XFilesFactor)) // If set by setXFilesFactor, all series in a list will have the same value

--- a/expr/functions/removeEmptySeries/function_test.go
+++ b/expr/functions/removeEmptySeries/function_test.go
@@ -98,11 +98,39 @@ func TestFunction(t *testing.T) {
 			},
 		},
 		{
+			"removeZeroSeries(metric*,0.8)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, math.NaN()}, 1, now32),
+					types.MakeMetricData("metric2", []float64{1, 2, -1, 7, 8, 20, 23, 12, math.NaN(), math.NaN()}, 1, now32),
+					types.MakeMetricData("metric3", []float64{1, 2, -1, 7, 8, 20, 23, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+					types.MakeMetricData("metric4", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+					types.MakeMetricData("metric5", []float64{0, 0, 0, 0, 0, 0, 0, 0}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, math.NaN()}, 1, now32),
+				types.MakeMetricData("metric2", []float64{1, 2, -1, 7, 8, 20, 23, 12, math.NaN(), math.NaN()}, 1, now32),
+			},
+		},
+		{
 			"removeEmptySeries(metric*,1)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric*", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, -2.3}, 1, now32),
 					types.MakeMetricData("metric2", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, -2.3}, 1, now32),
+			},
+		},
+		{
+			"removeZeroSeries(metric*,1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, -2.3}, 1, now32),
+					types.MakeMetricData("metric2", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, 0}, 1, now32),
 				},
 			},
 			[]*types.MetricData{

--- a/expr/functions/removeEmptySeries/function_test.go
+++ b/expr/functions/removeEmptySeries/function_test.go
@@ -137,6 +137,16 @@ func TestFunction(t *testing.T) {
 				types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, -2.3}, 1, now32),
 			},
 		},
+		{
+			"removeEmptySeries(metric*,0.5)", // Verify that passing in empty series with an xFilesFactor does not result in an error
+			nil,
+			[]*types.MetricData{},
+		},
+		{
+			"removeZeroSeries(metric*,0.5)", // Verify that passing in empty series with an xFilesFactor does not result in an error
+			nil,
+			[]*types.MetricData{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/functions/round/function.go
+++ b/expr/functions/round/function.go
@@ -2,7 +2,6 @@ package round
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -41,9 +40,7 @@ func (f *round) Do(ctx context.Context, e parser.Expr, from, until int64, values
 	if err != nil {
 		return nil, err
 	}
-	if withPrecision {
-		precisionStr = strconv.Itoa(precision)
-	}
+	precisionStr = strconv.Itoa(precision)
 
 	results := make([]*types.MetricData, len(arg))
 	for j, a := range arg {
@@ -59,7 +56,7 @@ func (f *round) Do(ctx context.Context, e parser.Expr, from, until int64, values
 			r.Values[i] = helper.SafeRound(v, precision)
 		}
 
-		r.Tags["round"] = fmt.Sprintf("%d", precision)
+		r.Tags["round"] = precisionStr
 		results[j] = r
 
 	}

--- a/expr/functions/scale/function.go
+++ b/expr/functions/scale/function.go
@@ -2,7 +2,6 @@ package scale
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -51,11 +50,10 @@ func (f *scale) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		if timestamp == 0 {
 			r.Name = "scale(" + a.Name + "," + scaleStr + ")"
 		} else {
-			r.Name = fmt.Sprintf("scale(%s,%g,%d)", a.Name, scale, timestamp)
 			r.Name = "scale(" + a.Name + "," + scaleStr + "," + e.Arg(2).StringValue() + ")"
 		}
 		r.Values = make([]float64, len(a.Values))
-		r.Tags["scale"] = fmt.Sprintf("%f", scale)
+		r.Tags["scale"] = scaleStr
 
 		currentTimestamp := a.StartTime
 		for i, v := range a.Values {

--- a/expr/functions/scaleToSeconds/function.go
+++ b/expr/functions/scaleToSeconds/function.go
@@ -2,7 +2,6 @@ package scaleToSeconds
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -47,7 +46,7 @@ func (f *scaleToSeconds) Do(ctx context.Context, e parser.Expr, from, until int6
 		r := a.CopyLink()
 		r.Name = "scaleToSeconds(" + a.Name + "," + secondsStr + ")"
 		r.Values = make([]float64, len(a.Values))
-		r.Tags["scaleToSeconds"] = fmt.Sprintf("%f", seconds)
+		r.Tags["scaleToSeconds"] = secondsStr
 
 		factor := seconds / float64(a.StepTime)
 

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -150,13 +150,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 			}
 		}
 		if pairFound {
-			pair := []*types.MetricData{numerator, denominator}
-			step, alignStep := helper.GetCommonStep(pair)
-			if alignStep || len(numerator.Values) != len(denominator.Values) {
-				alignedSeries := helper.ScaleToCommonStep(types.CopyMetricDataSlice(pair), step)
-				numerator = alignedSeries[0]
-				denominator = alignedSeries[1]
-			}
+			numerator, denominator = helper.ConsolidateSeriesByStep(numerator, denominator)
 		}
 
 		r := numerator.CopyLink()

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -2,7 +2,6 @@ package seriesList
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -151,11 +150,16 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 			}
 		}
 		if pairFound {
-			if numerator.StepTime != denominator.StepTime || len(numerator.Values) != len(denominator.Values) {
-				return nil, fmt.Errorf("series %s must have the same length as %s", numerator.Name, denominator.Name)
+			pair := []*types.MetricData{numerator, denominator}
+			step, alignStep := helper.GetCommonStep(pair)
+			if alignStep || len(numerator.Values) != len(denominator.Values) {
+				alignedSeries := helper.ScaleToCommonStep(types.CopyMetricDataSlice(pair), step)
+				numerator = alignedSeries[0]
+				denominator = alignedSeries[1]
 			}
 		}
-		r := *numerator
+
+		r := numerator.CopyLink()
 		var denomName string
 		if pairFound {
 			denomName = denominator.Name
@@ -188,7 +192,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 				r.Values[i] = compute(v, denomValue)
 			}
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/sigmoid/function.go
+++ b/expr/functions/sigmoid/function.go
@@ -2,7 +2,6 @@ package sigmoid
 
 import (
 	"context"
-	"fmt"
 	"math"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -39,7 +38,7 @@ func (f *sigmoid) Do(ctx context.Context, e parser.Expr, from, until int64, valu
 
 	for _, a := range arg {
 		r := a.CopyLink()
-		r.Name = fmt.Sprintf("sigmoid(%s)", a.Name)
+		r.Name = "sigmoid(" + a.Name + ")"
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["sigmoid"] = "sigmoid"
 

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -54,6 +54,9 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 	if err != nil {
 		return nil, err
 	}
+	if err := consolidations.CheckValidConsolidationFunc(summarizeFunction); err != nil {
+		return nil, err
+	}
 
 	alignToInterval, err := e.GetStringNamedOrPosArgDefault("alignTo", 3, "")
 	if err != nil {

--- a/expr/functions/sortBy/function.go
+++ b/expr/functions/sortBy/function.go
@@ -63,6 +63,9 @@ func (f *sortBy) Do(ctx context.Context, e parser.Expr, from, until int64, value
 	if !exists {
 		return nil, fmt.Errorf("invalid function called: %s", target)
 	}
+	if err := consolidations.CheckValidConsolidationFunc(aggFunc.name); err != nil {
+		return nil, err
+	}
 
 	// some function by default are not ascending so we need to reverse behaviour
 	if !aggFunc.ascending {

--- a/expr/functions/sortBy/function_test.go
+++ b/expr/functions/sortBy/function_test.go
@@ -1,6 +1,7 @@
 package sortBy
 
 import (
+	"github.com/go-graphite/carbonapi/expr/consolidations"
 	"testing"
 	"time"
 
@@ -125,4 +126,30 @@ func TestFunction(t *testing.T) {
 		})
 	}
 
+}
+
+func TestErrorInvalidConsolidationFunction(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItemWithError{
+		{
+			"sortBy(metric*, 'test')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					types.MakeMetricData("metricB", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					types.MakeMetricData("metricC", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+				},
+			},
+			nil,
+			consolidations.ErrInvalidConsolidationFunc,
+		},
+	}
+
+	for _, testCase := range tests {
+		testName := testCase.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithError(t, &testCase)
+		})
+	}
 }

--- a/expr/functions/sumSeriesWithWildcards/function.go
+++ b/expr/functions/sumSeriesWithWildcards/function.go
@@ -2,7 +2,6 @@ package sumSeriesWithWildcards
 
 import (
 	"context"
-	"github.com/go-graphite/carbonapi/expr/helper/metric"
 	"math"
 	"strings"
 
@@ -47,7 +46,7 @@ func (f *sumSeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from, un
 	groups := make(map[string][]*types.MetricData)
 
 	for _, a := range args {
-		metric := metric.ExtractMetric(a.Name)
+		metric := types.ExtractNameTag(a.Name)
 		nodes := strings.Split(metric, ".")
 		s := make([]string, 0, len(nodes))
 		// Yes, this is O(n^2), but len(nodes) < 10 and len(fields) < 3

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -56,6 +56,9 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	if !funcOk {
 		funcOk = e.ArgsLen() > 2
 	}
+	if err := consolidations.CheckValidConsolidationFunc(summarizeFunction); err != nil {
+		return nil, err
+	}
 
 	alignToFrom, err := e.GetBoolNamedOrPosArgDefault("alignToFrom", 3, false)
 	if err != nil {

--- a/expr/functions/timeSlice/function.go
+++ b/expr/functions/timeSlice/function.go
@@ -2,7 +2,6 @@ package timeSlice
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 	"time"
@@ -60,8 +59,8 @@ func (f *timeSlice) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		r := a.CopyLink()
 		r.Name = "timeSlice(" + a.Name + "," + startStr + "," + endStr + ")"
 		r.Values = make([]float64, len(a.Values))
-		r.Tags["timeSliceStart"] = fmt.Sprintf("%d", start)
-		r.Tags["timeSliceEnd"] = fmt.Sprintf("%d", end)
+		r.Tags["timeSliceStart"] = startStr
+		r.Tags["timeSliceEnd"] = endStr
 
 		current := from
 		for i, v := range a.Values {

--- a/expr/functions/timeStack/function.go
+++ b/expr/functions/timeStack/function.go
@@ -3,6 +3,7 @@ package timeStack
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
@@ -34,6 +35,7 @@ func (f *timeStack) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	if err != nil {
 		return nil, err
 	}
+	unitStr := e.Arg(1).StringValue()
 
 	start, err := e.GetIntArg(2)
 	if err != nil {
@@ -55,13 +57,14 @@ func (f *timeStack) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			return nil, err
 		}
 
+		offsStr := strconv.FormatInt(offs, 10)
 		for _, a := range arg {
 			r := a.CopyLink()
 			r.Name = fmt.Sprintf("timeShift(%s,%d)", a.Name, offs)
 			r.StartTime = a.StartTime - offs
 			r.StopTime = a.StopTime - offs
-			r.Tags["timeShiftUnit"] = fmt.Sprintf("%d", unit)
-			r.Tags["timeShift"] = fmt.Sprintf("%d", offs)
+			r.Tags["timeShiftUnit"] = unitStr
+			r.Tags["timeShift"] = offsStr
 			results = append(results, r)
 		}
 	}

--- a/expr/functions/transformNull/function.go
+++ b/expr/functions/transformNull/function.go
@@ -93,7 +93,7 @@ func (f *transformNull) Do(ctx context.Context, e parser.Expr, from, until int64
 
 		r := a.CopyName(name)
 		r.Values = make([]float64, len(a.Values))
-		r.Tags["transformNull"] = fmt.Sprintf("%f", defv)
+		r.Tags["transformNull"] = defvStr
 
 		for i, v := range a.Values {
 			if math.IsNaN(v) {

--- a/expr/helper/align.go
+++ b/expr/helper/align.go
@@ -75,7 +75,7 @@ func GetStepRange(args []*types.MetricData) (minStep, maxStep int64, needScale b
 // It respects xFilesFactor and fills gaps in the begin and end with NaNs if needed.
 func ScaleToCommonStep(args []*types.MetricData, commonStep int64) []*types.MetricData {
 	if commonStep < 0 || len(args) == 0 {
-		// This doesn't make sence
+		// This doesn't make sense
 		return args
 	}
 
@@ -377,6 +377,21 @@ func ScaleSeries(args []*types.MetricData) []*types.MetricData {
 	}
 
 	return args
+}
+
+func ConsolidateSeriesByStep(numerator, denominator *types.MetricData) (*types.MetricData, *types.MetricData) {
+	pair := []*types.MetricData{numerator, denominator}
+
+	step, changed := GetCommonStep(pair)
+	if changed || len(numerator.Values) != len(denominator.Values) {
+		alignedSeries := ScaleToCommonStep(types.CopyMetricDataSlice(pair), step)
+		numerator = alignedSeries[0]
+		denominator = alignedSeries[1]
+
+		return alignedSeries[0], alignedSeries[1]
+	}
+
+	return numerator, denominator
 }
 
 func genNaNs(length int) []float64 {

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/go-graphite/carbonapi/expr/helper/metric"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
@@ -93,7 +92,7 @@ func GetSeriesArgsAndRemoveNonExisting(ctx context.Context, e parser.Expr, from,
 func AggKey(arg *types.MetricData, nodesOrTags []parser.NodeOrTag) string {
 	matched := make([]string, 0, len(nodesOrTags))
 	metricTags := arg.Tags
-	name := metric.ExtractMetric(arg.Name)
+	name := types.ExtractNameTag(arg.Name)
 	nodes := strings.Split(name, ".")
 	for _, nt := range nodesOrTags {
 		if nt.IsTag {

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -180,8 +180,10 @@ func AggregateSeries(e parser.Expr, args []*types.MetricData, function Aggregate
 
 		r.Values[i] = math.NaN()
 		if len(values) > 0 {
-			if applyXFilesFactor && XFilesFactorValues(values, xFilesFactor) {
-				r.Values[i] = function(values)
+			if applyXFilesFactor && !XFilesFactorValues(values, xFilesFactor) {
+				// if an xFileFactor is specified and the ratio of NaN values to non-NaN values is not equal to
+				// or greater than the xFilesFactor, the value should be NaN
+				r.Values[i] = math.NaN()
 			} else {
 				r.Values[i] = function(values)
 			}

--- a/expr/types/extract.go
+++ b/expr/types/extract.go
@@ -64,3 +64,47 @@ func ExtractName(s string) string {
 	start, end := ExtractNameLoc(s)
 	return s[start:end]
 }
+
+// ExtractNameTag extracts name tag out of function list with . Only for use in MetrciData name parse, it's has more allowed chard in names, like =
+func ExtractNameTag(s string) string {
+	// search for a metric name in 's'
+	// metric name is defined to be a Series of name characters terminated by a ',' or ')'
+
+	var w, i, start, braces int
+	var c rune
+FOR:
+	for i, c = range s {
+		w = i
+		switch c {
+		case '{':
+			braces++
+		case '}':
+			if braces == 0 {
+				break FOR
+			}
+			braces--
+		case ',':
+			if braces == 0 {
+				break FOR
+			}
+		case '(':
+			if i >= 11 {
+				n := i - 11
+				if s[n:i] == "seriesByTag" {
+					end := strings.IndexRune(s[n:], ')')
+					if end == -1 {
+						return s[n:len(s)] // broken end of args, can't exist in correctly parsed functions
+					} else {
+						return s[n : n+end+1]
+					}
+				}
+			}
+			start = i + 1
+		case ')', ';':
+			break FOR
+		}
+		w += utf8.RuneLen(c)
+	}
+
+	return s[start:w]
+}

--- a/expr/types/extract_test.go
+++ b/expr/types/extract_test.go
@@ -88,12 +88,121 @@ func TestExtractName(t *testing.T) {
 			"sum(seriesByTag('tag2=value*', 'name=metric'))",
 			"seriesByTag('tag2=value*', 'name=metric')",
 		},
+		{
+			"sum(metric.name;tag=value)",
+			"metric.name;tag=value",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			if m := ExtractName(tt.input); m != tt.metric {
 				t.Errorf("extractMetric(%q)=%q, want %q", tt.input, m, tt.metric)
+			}
+		})
+	}
+}
+
+func TestExtractNameTag(t *testing.T) {
+	var tests = []struct {
+		input  string
+		metric string
+	}{
+		{
+			"f",
+			"f",
+		},
+		{
+			"func(f)",
+			"f",
+		},
+		{
+			"foo.bar.baz",
+			"foo.bar.baz",
+		},
+		{
+			"nonNegativeDerivative(foo.bar.baz)",
+			"foo.bar.baz",
+		},
+		{
+			"movingAverage(foo.bar.baz,10)",
+			"foo.bar.baz",
+		},
+		{
+			"scale(scaleToSeconds(nonNegativeDerivative(foo.bar.baz),60),60)",
+			"foo.bar.baz",
+		},
+		{
+			"divideSeries(foo.bar.baz,baz.qux.zot)",
+			"foo.bar.baz",
+		},
+		{
+			"{something}",
+			"{something}",
+		},
+		{
+			"ab=",
+			"ab=",
+		},
+		{
+			"ab=.c",
+			"ab=.c",
+		},
+		{
+			"ab==",
+			"ab==",
+		},
+		{
+			"scale(scaleToSeconds(nonNegativeDerivative(ab==.c),60),60)",
+			"ab==.c",
+		},
+		{
+			"divideSeries(metric[12])",
+			"metric[12]",
+		},
+		{
+			"average(metric{1,2}e,'sum')",
+			"metric{1,2}e",
+		},
+		{
+			"aliasByNode(alias(0.1.2.@.4, 2), 1)",
+			"0.1.2.@.4",
+		},
+		{
+			"aliasByTags(alias(0.1.2.@.4, 2), 1)",
+			"0.1.2.@.4",
+		},
+		// non-ASCII symbols
+		{
+			"alias(Количество изменений)",
+			"Количество изменений",
+		},
+		{
+			"some(Количество изменений, Аргумент)",
+			"Количество изменений",
+		},
+		{
+			"seriesByTag('tag2=value*', 'name=metric')",
+			"seriesByTag('tag2=value*', 'name=metric')",
+		},
+		{
+			"sum(seriesByTag('tag2=value*', 'name=metric'))",
+			"seriesByTag('tag2=value*', 'name=metric')",
+		},
+		{
+			"sum(metric.name;tag=value)",
+			"metric.name",
+		},
+		{
+			"metric1.foo==.bar.baz",
+			"metric1.foo==.bar.baz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if m := ExtractNameTag(tt.input); m != tt.metric {
+				t.Errorf("ExtractNameTag(%q)=%q, want %q", tt.input, m, tt.metric)
 			}
 		})
 	}

--- a/pkg/parser/internal.go
+++ b/pkg/parser/internal.go
@@ -2,12 +2,17 @@ package parser
 
 import (
 	"fmt"
+	"strconv"
 
 	"runtime/debug"
 )
 
 func (e *expr) doGetIntArg() (int, error) {
 	if e.etype != EtConst {
+		if e.etype == EtString {
+			f, err := strconv.ParseInt(e.valStr, 0, 64)
+			return int(f), err
+		}
 		return 0, ErrBadType
 	}
 
@@ -24,6 +29,10 @@ func (e *expr) getNamedArg(name string) *expr {
 
 func (e *expr) doGetFloatArg() (float64, error) {
 	if e.etype != EtConst {
+		if e.etype == EtString {
+			f, err := strconv.ParseFloat(e.valStr, 64)
+			return f, err
+		}
 		return 0, ErrBadType
 	}
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -420,3 +420,61 @@ func TestDoGetBoolVar(t *testing.T) {
 		})
 	}
 }
+
+func TestDoGetFloatArg(t *testing.T) {
+	tests := []struct {
+		s string
+		e *expr
+		r float64
+	}{
+		{
+			"parse float",
+			&expr{val: 1.0, etype: EtConst, valStr: "1.0"},
+			1.0,
+		},
+		{
+			"parse string to float",
+			&expr{etype: EtString, valStr: "1.0"},
+			1.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r, err := tt.e.doGetFloatArg()
+			if assert.NoError(err) {
+				assert.Equal(tt.r, r, tt.s)
+			}
+		})
+	}
+}
+
+func TestDoGetIntArg(t *testing.T) {
+	tests := []struct {
+		s string
+		e *expr
+		r int
+	}{
+		{
+			"parse int",
+			&expr{val: 5, etype: EtConst, valStr: "5"},
+			5,
+		},
+		{
+			"parse string to int",
+			&expr{etype: EtString, valStr: "1"},
+			1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r, err := tt.e.doGetIntArg()
+			if assert.NoError(err) {
+				assert.Equal(tt.r, r, tt.s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for the Graphite web holtWintersConfidenceArea() function.

The holtWintersConfidenceArea() function is defined as:

```
holtWintersConfidenceArea(seriesList, delta=3, bootstrapInterval='7d', seasonality='1d')
Performs a Holt-Winters forecast using the series as input data and plots the area between the upper and lower bands of the predicted forecast deviations.
```