### PR TITLE
Make functions don't mutate input data

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -281,11 +281,7 @@ func TestEvalExpression(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 }

--- a/expr/functions/absolute/function_test.go
+++ b/expr/functions/absolute/function_test.go
@@ -38,11 +38,7 @@ func TestAbsolute(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -272,11 +272,7 @@ func TestAverageSeries(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/aliasByNode/function_test.go
+++ b/expr/functions/aliasByNode/function_test.go
@@ -113,11 +113,7 @@ func TestAliasByNode(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -149,11 +149,7 @@ func TestAliasByNode(t *testing.T) {
 	for _, tt := range testAlignments {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 }

--- a/expr/functions/cairo/cairo_test.go
+++ b/expr/functions/cairo/cairo_test.go
@@ -73,6 +73,6 @@ func TestEvalExpressionGraph(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
+		th.TestEvalExpr(t, &tt)
 	}
 }

--- a/expr/functions/delay/function.go
+++ b/expr/functions/delay/function.go
@@ -62,12 +62,12 @@ func (f *delay) Do(ctx context.Context, e parser.Expr, from, until int64, values
 			prevValues = append(prevValues, value)
 		}
 
-		result := *series
+		result := series.CopyLink()
 		result.Name = fmt.Sprintf("delay(%s,%d)", series.Name, steps)
 		result.Values = newValues
 		result.Tags["delay"] = fmt.Sprintf("%d", steps)
 
-		results = append(results, &result)
+		results = append(results, result)
 	}
 
 	return results, nil

--- a/expr/functions/delay/function_test.go
+++ b/expr/functions/delay/function_test.go
@@ -39,11 +39,7 @@ func TestDelay(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/derivative/function_test.go
+++ b/expr/functions/derivative/function_test.go
@@ -47,11 +47,7 @@ func TestDerivative(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -76,7 +76,7 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 
 	var results []*types.MetricData
 	for _, numerator := range numerators {
-		r := *numerator
+		r := numerator.CopyLink()
 		if useMetricNames {
 			r.Name = fmt.Sprintf("divideSeries(%s,%s)", numerator.Name, denominator.Name)
 		} else {
@@ -94,7 +94,7 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 
 			r.Values[i] = v / denominator.Values[i]
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 
 	return results, nil

--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -64,7 +64,7 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		return nil, errors.New("must be called with 2 series or a wildcard that matches exactly 2 series")
 	}
 
-	alignedSeries := helper.AlignSeries(append(numerators, denominator))
+	alignedSeries := helper.AlignSeries(types.CopyMetricDataSlice(append(numerators, denominator)))
 	numerators = alignedSeries[:len(numerators)]
 	denominator = alignedSeries[len(numerators)]
 

--- a/expr/functions/divideSeries/function_test.go
+++ b/expr/functions/divideSeries/function_test.go
@@ -123,11 +123,7 @@ func TestDivideSeriesAligned(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 }

--- a/expr/functions/exp/function.go
+++ b/expr/functions/exp/function.go
@@ -37,7 +37,7 @@ func (f *exp) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 	var results []*types.MetricData
 
 	for _, a := range args {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("exp(%s)", a.Name)
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["exp"] = "e"
@@ -49,7 +49,7 @@ func (f *exp) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 				r.Values[i] = math.Exp(v)
 			}
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/exp/function_test.go
+++ b/expr/functions/exp/function_test.go
@@ -39,11 +39,7 @@ func TestExp(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/integral/function_test.go
+++ b/expr/functions/integral/function_test.go
@@ -39,11 +39,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/integralByInterval/function.go
+++ b/expr/functions/integralByInterval/function.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 
-	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 	"github.com/grafana/carbonapi/expr/helper"
 	"github.com/grafana/carbonapi/expr/interfaces"
 	"github.com/grafana/carbonapi/expr/types"
@@ -57,19 +56,11 @@ func (f *integralByInterval) Do(ctx context.Context, e parser.Expr, from, until 
 		currentTime := arg.StartTime
 
 		name := fmt.Sprintf("integralByInterval(%s,'%s')", arg.Name, e.Args()[1].StringValue())
-		result := types.MetricData{
-			FetchResponse: pb.FetchResponse{
-				Name:              name,
-				Values:            make([]float64, len(arg.Values)),
-				StepTime:          arg.StepTime,
-				StartTime:         arg.StartTime,
-				StopTime:          arg.StopTime,
-				XFilesFactor:      arg.XFilesFactor,
-				PathExpression:    name,
-				ConsolidationFunc: arg.ConsolidationFunc,
-			},
-			Tags: arg.Tags,
-		}
+		result := arg.CopyLink()
+		result.Name = name
+		result.PathExpression = name
+		result.Values = make([]float64, len(arg.Values))
+
 		result.Tags["integralByInterval"] = intervalString
 
 		for i, v := range arg.Values {
@@ -84,7 +75,7 @@ func (f *integralByInterval) Do(ctx context.Context, e parser.Expr, from, until 
 			currentTime += arg.StepTime
 		}
 
-		results = append(results, &result)
+		results = append(results, result)
 	}
 
 	return results, nil

--- a/expr/functions/integralByInterval/function_test.go
+++ b/expr/functions/integralByInterval/function_test.go
@@ -39,11 +39,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/invert/function_test.go
+++ b/expr/functions/invert/function_test.go
@@ -39,11 +39,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/isNotNull/function_test.go
+++ b/expr/functions/isNotNull/function_test.go
@@ -52,11 +52,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/linearRegression/function.go
+++ b/expr/functions/linearRegression/function.go
@@ -43,7 +43,7 @@ func (f *linearRegression) Do(ctx context.Context, e parser.Expr, from, until in
 	var results []*types.MetricData
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		if len(e.Args()) > 2 {
 			r.Name = fmt.Sprintf("linearRegression(%s,'%s','%s')", a.GetName(), e.Args()[1].StringValue(), e.Args()[2].StringValue())
 		} else if len(e.Args()) > 1 {
@@ -66,7 +66,7 @@ func (f *linearRegression) Do(ctx context.Context, e parser.Expr, from, until in
 			for i := range r.Values {
 				r.Values[i] = math.NaN()
 			}
-			results = append(results, &r)
+			results = append(results, r)
 			continue
 		}
 
@@ -90,7 +90,7 @@ func (f *linearRegression) Do(ctx context.Context, e parser.Expr, from, until in
 		}
 		r.Tags["linearRegressions"] = fmt.Sprintf("%d, %d", a.GetStartTime(), a.GetStopTime())
 
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/linearRegression/function_test.go
+++ b/expr/functions/linearRegression/function_test.go
@@ -44,11 +44,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/logarithm/function.go
+++ b/expr/functions/logarithm/function.go
@@ -58,7 +58,7 @@ func (f *logarithm) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			name = fmt.Sprintf("logarithm(%s)", a.Name)
 		}
 
-		r := *a
+		r := a.CopyLink()
 		r.Name = name
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["log"] = fmt.Sprintf("%f", baseLog)
@@ -66,7 +66,7 @@ func (f *logarithm) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		for i, v := range a.Values {
 			r.Values[i] = math.Log(v) / baseLog
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/logarithm/function_test.go
+++ b/expr/functions/logarithm/function_test.go
@@ -46,11 +46,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/logit/function.go
+++ b/expr/functions/logit/function.go
@@ -39,7 +39,7 @@ func (f *logit) Do(ctx context.Context, e parser.Expr, from, until int64, values
 
 	var results []*types.MetricData
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("logit(%s)", a.Name)
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["logit"] = "logit"
@@ -51,7 +51,7 @@ func (f *logit) Do(ctx context.Context, e parser.Expr, from, until int64, values
 				r.Values[i] = math.Log(v / (1 - v))
 			}
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/logit/function_test.go
+++ b/expr/functions/logit/function_test.go
@@ -40,11 +40,7 @@ func TestFunction(t *testing.T) {
 		tt := tt
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 }

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -123,7 +123,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 	}
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("%s(%s,%s)", e.Target(), a.Name, argstr)
 
 		if windowSize == 0 {
@@ -133,7 +133,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 					r.Values[i] = math.NaN()
 				}
 			}
-			result = append(result, &r)
+			result = append(result, r)
 			continue
 		}
 		r.Values = make([]float64, len(a.Values)-offset)
@@ -162,7 +162,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			w.Push(v)
 		}
 		r.Tags[e.Target()] = fmt.Sprintf("%d", windowSize)
-		result = append(result, &r)
+		result = append(result, r)
 	}
 	return result, nil
 }

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -73,11 +73,7 @@ func TestMoving(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -118,7 +118,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 	}
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("movingMedian(%s,%s)", a.Name, argstr)
 
 		if windowSize == 0 {
@@ -128,7 +128,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 					r.Values[i] = math.NaN()
 				}
 			}
-			result = append(result, &r)
+			result = append(result, r)
 			continue
 		}
 		r.Values = make([]float64, len(a.Values)-offset)
@@ -148,7 +148,7 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int64,
 			}
 		}
 		r.Tags["movingMedian"] = fmt.Sprintf("%d", windowSize)
-		result = append(result, &r)
+		result = append(result, r)
 	}
 	return result, nil
 }

--- a/expr/functions/movingMedian/function_test.go
+++ b/expr/functions/movingMedian/function_test.go
@@ -66,11 +66,7 @@ func TestMovingMedian(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/nPercentile/function.go
+++ b/expr/functions/nPercentile/function.go
@@ -43,7 +43,7 @@ func (f *nPercentile) Do(ctx context.Context, e parser.Expr, from, until int64, 
 
 	var results []*types.MetricData
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("nPercentile(%s,%g)", a.Name, percent)
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["nPercentile"] = fmt.Sprintf("%f", percent)
@@ -59,7 +59,7 @@ func (f *nPercentile) Do(ctx context.Context, e parser.Expr, from, until int64, 
 			r.Values[i] = value
 		}
 
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/nPercentile/function_test.go
+++ b/expr/functions/nPercentile/function_test.go
@@ -38,11 +38,7 @@ func TestNPercentile(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/nonNegativeDerivative/function.go
+++ b/expr/functions/nonNegativeDerivative/function.go
@@ -76,7 +76,7 @@ func (f *nonNegativeDerivative) Do(ctx context.Context, e parser.Expr, from, unt
 			name = fmt.Sprintf("nonNegativeDerivative(%s)", a.Name)
 		}
 
-		r := *a
+		r := a.CopyLink()
 		r.Name = name
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["nonNegativeDerivative"] = "1"
@@ -101,7 +101,7 @@ func (f *nonNegativeDerivative) Do(ctx context.Context, e parser.Expr, from, unt
 			}
 			prev = v
 		}
-		result = append(result, &r)
+		result = append(result, r)
 	}
 	return result, nil
 }

--- a/expr/functions/nonNegativeDerivative/function_test.go
+++ b/expr/functions/nonNegativeDerivative/function_test.go
@@ -59,11 +59,7 @@ func TestNonNegativeDerivative(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/offset/function.go
+++ b/expr/functions/offset/function.go
@@ -41,7 +41,7 @@ func (f *offset) Do(ctx context.Context, e parser.Expr, from, until int64, value
 	var results []*types.MetricData
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("%s(%s,%g)", e.Target(), a.Name, factor)
 		r.Values = make([]float64, len(a.Values))
 		r.Tags[e.Target()] = fmt.Sprintf("%f", factor)
@@ -49,7 +49,7 @@ func (f *offset) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		for i, v := range a.Values {
 			r.Values[i] = v + factor
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/offset/function_test.go
+++ b/expr/functions/offset/function_test.go
@@ -52,11 +52,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/offsetToZero/function_test.go
+++ b/expr/functions/offsetToZero/function_test.go
@@ -39,11 +39,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/perSecond/function.go
+++ b/expr/functions/perSecond/function.go
@@ -78,7 +78,7 @@ func (f *perSecond) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			name = fmt.Sprintf("perSecond(%s)", a.Name)
 		}
 
-		r := *a
+		r := a.CopyLink()
 		r.Name = name
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["perSecond"] = "1"
@@ -103,7 +103,7 @@ func (f *perSecond) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			}
 			prev = v
 		}
-		result = append(result, &r)
+		result = append(result, r)
 	}
 	return result, nil
 }

--- a/expr/functions/perSecond/function_test.go
+++ b/expr/functions/perSecond/function_test.go
@@ -52,11 +52,7 @@ func TestPerSecond(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/pow/function.go
+++ b/expr/functions/pow/function.go
@@ -42,7 +42,7 @@ func (f *pow) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 	var results []*types.MetricData
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("pow(%s,%g)", a.Name, factor)
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["pow"] = fmt.Sprintf("%f", factor)
@@ -54,7 +54,7 @@ func (f *pow) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 				r.Values[i] = math.Pow(v, factor)
 			}
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/pow/function_test.go
+++ b/expr/functions/pow/function_test.go
@@ -45,11 +45,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/rangeOfSeries/function_test.go
+++ b/expr/functions/rangeOfSeries/function_test.go
@@ -43,11 +43,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/removeBelowSeries/function.go
+++ b/expr/functions/removeBelowSeries/function.go
@@ -68,7 +68,7 @@ func (f *removeBelowSeries) Do(ctx context.Context, e parser.Expr, from, until i
 			threshold = consolidations.Percentile(values, number, true)
 		}
 
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("%s(%s, %g)", e.Target(), a.Name, number)
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["removeBelowSeries"] = fmt.Sprintf("%f", threshold)
@@ -82,7 +82,7 @@ func (f *removeBelowSeries) Do(ctx context.Context, e parser.Expr, from, until i
 			r.Values[i] = v
 		}
 
-		results = append(results, &r)
+		results = append(results, r)
 	}
 
 	return results, nil

--- a/expr/functions/removeBelowSeries/function_test.go
+++ b/expr/functions/removeBelowSeries/function_test.go
@@ -63,11 +63,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/removeEmptySeries/function.go
+++ b/expr/functions/removeEmptySeries/function.go
@@ -57,9 +57,10 @@ func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until i
 				}
 			}
 		}
-		arg.Tags[e.Target()] = fmt.Sprintf("%f", factor)
 		if nonNull != 0 && nonNull/float64(len(arg.Values)) >= factor {
-			results = append(results, arg)
+			r := arg.CopyLink()
+			r.Tags[e.Target()] = fmt.Sprintf("%f", factor)
+			results = append(results, r)
 		}
 	}
 	return results, nil

--- a/expr/functions/removeEmptySeries/function_test.go
+++ b/expr/functions/removeEmptySeries/function_test.go
@@ -114,11 +114,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/round/function.go
+++ b/expr/functions/round/function.go
@@ -43,7 +43,7 @@ func (f *round) Do(ctx context.Context, e parser.Expr, from, until int64, values
 
 	results := make([]*types.MetricData, 0, len(arg))
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		if withPrecision {
 			r.Name = fmt.Sprintf("round(%s,%d)", a.Name, precision)
 		} else {
@@ -55,7 +55,7 @@ func (f *round) Do(ctx context.Context, e parser.Expr, from, until int64, values
 			r.Values[i] = doRound(v, precision)
 		}
 		r.Tags["round"] = fmt.Sprintf("%d", precision)
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/round/function_test.go
+++ b/expr/functions/round/function_test.go
@@ -73,11 +73,7 @@ func TestHeatMap(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 }

--- a/expr/functions/scale/function.go
+++ b/expr/functions/scale/function.go
@@ -45,7 +45,7 @@ func (f *scale) Do(ctx context.Context, e parser.Expr, from, until int64, values
 
 	results := make([]*types.MetricData, 0, len(arg))
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		if timestamp == 0 {
 			r.Name = fmt.Sprintf("scale(%s,%g)", a.Name, scale)
 		} else {
@@ -63,7 +63,7 @@ func (f *scale) Do(ctx context.Context, e parser.Expr, from, until int64, values
 
 			currentTimestamp += a.StepTime
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/scale/function_test.go
+++ b/expr/functions/scale/function_test.go
@@ -64,11 +64,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/scaleToSeconds/function.go
+++ b/expr/functions/scaleToSeconds/function.go
@@ -42,7 +42,7 @@ func (f *scaleToSeconds) Do(ctx context.Context, e parser.Expr, from, until int6
 	var results []*types.MetricData
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("scaleToSeconds(%s,%d)", a.Name, int(seconds))
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["scaleToSeconds"] = fmt.Sprintf("%f", seconds)
@@ -52,7 +52,7 @@ func (f *scaleToSeconds) Do(ctx context.Context, e parser.Expr, from, until int6
 		for i, v := range a.Values {
 			r.Values[i] = v * factor
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/scaleToSeconds/function_test.go
+++ b/expr/functions/scaleToSeconds/function_test.go
@@ -38,11 +38,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -84,7 +84,7 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 				StopTime:          stop,
 				ConsolidationFunc: summarizeFunction,
 			},
-			Tags: arg.Tags,
+			Tags: helper.CopyTags(arg),
 		}
 		r.Tags["smartSummarize"] = fmt.Sprintf("%d", bucketSizeInt32)
 		r.Tags["smartSummarizeFunction"] = summarizeFunction

--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -106,11 +106,7 @@ func TestFunctionUseNameWithWildcards(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestMultiReturnEvalExprModifiedOrigin(t, &tt)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestMultiReturnEvalExpr(t, &tt)
 		})
 	}
 }

--- a/expr/functions/squareRoot/function.go
+++ b/expr/functions/squareRoot/function.go
@@ -38,7 +38,7 @@ func (f *squareRoot) Do(ctx context.Context, e parser.Expr, from, until int64, v
 	var results []*types.MetricData
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("squareRoot(%s)", a.Name)
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["squareRoot"] = "1"
@@ -46,7 +46,7 @@ func (f *squareRoot) Do(ctx context.Context, e parser.Expr, from, until int64, v
 		for i, v := range a.Values {
 			r.Values[i] = math.Sqrt(v)
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/squareRoot/function_test.go
+++ b/expr/functions/squareRoot/function_test.go
@@ -39,11 +39,7 @@ func TestFunction(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/timeShift/function.go
+++ b/expr/functions/timeShift/function.go
@@ -92,7 +92,7 @@ func (f *timeShift) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	results := make([]*types.MetricData, 0, len(arg))
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("timeShift(%s,'%d',%v)", a.Name, offs, resetEnd)
 		r.StartTime = a.StartTime - int64(offs)
 		r.StopTime = a.StopTime - int64(offs)
@@ -105,7 +105,7 @@ func (f *timeShift) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		}
 		r.Values = r.Values[:length]
 		r.Tags["timeshift"] = fmt.Sprintf("%d", offs)
-		results = append(results, &r)
+		results = append(results, r)
 	}
 
 	return results, nil

--- a/expr/functions/timeShift/function_test.go
+++ b/expr/functions/timeShift/function_test.go
@@ -100,7 +100,7 @@ func TestTimeShift(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExprWithRangeModifiedOrigin(t, &tt)
+			th.TestEvalExprWithRange(t, &tt)
 		})
 	}
 }

--- a/expr/functions/transformNull/function.go
+++ b/expr/functions/transformNull/function.go
@@ -86,7 +86,7 @@ func (f *transformNull) Do(ctx context.Context, e parser.Expr, from, until int64
 			name = fmt.Sprintf("transformNull(%s)", a.Name)
 		}
 
-		r := *a
+		r := a.CopyLink()
 		r.Name = name
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["transformNull"] = fmt.Sprintf("%f", defv)
@@ -103,7 +103,7 @@ func (f *transformNull) Do(ctx context.Context, e parser.Expr, from, until int64
 			r.Values[i] = v
 		}
 
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	if len(arg) == 0 && defaultOnAbsent {
 		values := []float64{defv, defv}

--- a/expr/functions/transformNull/function_test.go
+++ b/expr/functions/transformNull/function_test.go
@@ -64,11 +64,7 @@ func TestTransformNull(t *testing.T) {
 	for _, tt := range tests {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
-			err := th.TestEvalExprModifiedOrigin(t, &tt, 0, 1, false)
-			if err != nil {
-				t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-				return
-			}
+			th.TestEvalExpr(t, &tt)
 		})
 	}
 }

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -128,10 +128,10 @@ func ForEachSeriesDo(ctx context.Context, e parser.Expr, from, until int64, valu
 	var results []*types.MetricData
 
 	for _, a := range arg {
-		r := *a
+		r := a.CopyLink()
 		r.Name = fmt.Sprintf("%s(%s)", e.Target(), a.Name)
 		r.Values = make([]float64, len(a.Values))
-		results = append(results, function(a, &r))
+		results = append(results, function(a, r))
 	}
 	return results, nil
 }

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -569,15 +569,6 @@ func TestEvalExprWithRange(t *testing.T, tt *EvalTestItemWithRange) {
 	DeepEqual(t, tt.Target, originalMetrics, tt.M, true)
 }
 
-func TestEvalExprWithRangeModifiedOrigin(t *testing.T, tt *EvalTestItemWithRange) {
-	tt2 := tt.TestItem()
-	err := TestEvalExprModifiedOrigin(t, tt2, tt.From, tt.Until, false)
-	if err != nil {
-		t.Errorf("unexpected error while evaluating %s: got `%+v`", tt.Target, err)
-		return
-	}
-}
-
 func TestEvalExprWithError(t *testing.T, tt *EvalTestItemWithError) {
 	originalMetrics := DeepClone(tt.M)
 	tt2 := &EvalTestItem{

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -412,53 +412,6 @@ func TestMultiReturnEvalExpr(t *testing.T, tt *MultiReturnEvalTestItem) {
 	}
 }
 
-func TestMultiReturnEvalExprModifiedOrigin(t *testing.T, tt *MultiReturnEvalTestItem) error {
-	evaluator := metadata.GetEvaluator()
-
-	exp, _, err := parser.ParseExpr(tt.Target)
-	if err != nil {
-		t.Errorf("failed to parse %v: %+v", tt.Target, err)
-		return err
-	}
-	g, err := evaluator.Eval(context.Background(), exp, 0, 1, tt.M)
-	if err != nil {
-		t.Errorf("failed to eval %v: %+v", tt.Name, err)
-		return err
-	}
-	if len(g) == 0 {
-		t.Errorf("returned no data %v", tt.Name)
-		return nil
-	}
-	if g[0] == nil {
-		t.Errorf("returned no value %v", tt.Name)
-		return nil
-	}
-	if g[0].StepTime == 0 {
-		t.Errorf("missing Step for %+v", g)
-	}
-	if len(g) != len(tt.Results) {
-		t.Errorf("unexpected results len: got %d, want %d for %s", len(g), len(tt.Results), tt.Target)
-	}
-	for _, gg := range g {
-		r, ok := tt.Results[gg.Name]
-		if !ok {
-			t.Errorf("missing result Name: %v", gg.Name)
-			continue
-		}
-		if r[0].Name != gg.Name {
-			t.Errorf("result Name mismatch, got\n%#v,\nwant\n%#v", gg.Name, r[0].Name)
-		}
-		if !reflect.DeepEqual(r[0].Values, gg.Values) ||
-			r[0].StartTime != gg.StartTime ||
-			r[0].StopTime != gg.StopTime ||
-			r[0].StepTime != gg.StepTime {
-			t.Errorf("result mismatch, got\n%#v,\nwant\n%#v", gg, r)
-		}
-	}
-
-	return nil
-}
-
 type RewriteTestResult struct {
 	Rewritten bool
 	Targets   []string


### PR DESCRIPTION
Most functions were just doing something like:
```go
out := *input // MetricData
out.Values = make([]float64, len(input.Values))
...
```

Since `MetricData.Tags` is a map, altering tags in `out` was altering the ones in `input`.

Solution: use `input.CopyLink()`, which correctly copies everything but the Values (almost all functions just overwrite those).