### PR TITLE
Fix groupByNode handling of queries with no callback provided

### DIFF
--- a/expr/functions/groupByNode/function.go
+++ b/expr/functions/groupByNode/function.go
@@ -47,9 +47,13 @@ func (f *groupByNode) Do(ctx context.Context, e parser.Expr, from, until int64, 
 			return nil, err
 		}
 
-		callback, err = e.GetStringArg(2)
-		if err != nil {
-			return nil, err
+		if len(e.Args()) == 3 {
+			callback, err = e.GetStringArg(2)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			callback = "avg"
 		}
 		fields = []int{field}
 	} else {
@@ -153,7 +157,7 @@ func (f *groupByNode) Description() map[string]types.FunctionDescription {
 					Default:  types.NewSuggestion("average"),
 					Name:     "callback",
 					Options:  types.StringsToSuggestionList(consolidations.AvailableSummarizers),
-					Required: true,
+					Required: false,
 					Type:     types.AggFunc,
 				},
 			},
@@ -173,7 +177,7 @@ func (f *groupByNode) Description() map[string]types.FunctionDescription {
 				{
 					Name:     "callback",
 					Options:  types.StringsToSuggestionList(consolidations.AvailableSummarizers),
-					Required: true,
+					Required: false,
 					Type:     types.AggFunc,
 				},
 				{

--- a/expr/functions/groupByNode/function_test.go
+++ b/expr/functions/groupByNode/function_test.go
@@ -98,6 +98,22 @@ func TestGroupByNode(t *testing.T) {
 			},
 		},
 		{
+			Target: "groupByNode(metric1.foo.*.*,2)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				mr: {
+					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric1.foo.bar1.qux", []float64{6, 7, 8, 9, 10}, 1, now32),
+					types.MakeMetricData("metric1.foo.bar2.baz", []float64{11, 12, 13, 14, 15}, 1, now32),
+					types.MakeMetricData("metric1.foo.bar2.qux", []float64{7, 8, 9, 10, 11}, 1, now32),
+				},
+			},
+			Name: "groupByNode_with_no_callback_arg",
+			Results: map[string][]*types.MetricData{
+				"bar1": {types.MakeMetricData("bar1", []float64{7, 9, 11, 13, 15}, 1, now32)},
+				"bar2": {types.MakeMetricData("bar2", []float64{18, 20, 22, 24, 26}, 1, now32)},
+			},
+		},
+		{
 			Target: "groupByNodes(metric1.foo.*.*,\"sum\",0,1,3)",
 			M: map[parser.MetricRequest][]*types.MetricData{
 				mr: {

--- a/expr/functions/groupByNode/function_test.go
+++ b/expr/functions/groupByNode/function_test.go
@@ -109,8 +109,8 @@ func TestGroupByNode(t *testing.T) {
 			},
 			Name: "groupByNode_with_no_callback_arg",
 			Results: map[string][]*types.MetricData{
-				"bar1": {types.MakeMetricData("bar1", []float64{7, 9, 11, 13, 15}, 1, now32)},
-				"bar2": {types.MakeMetricData("bar2", []float64{18, 20, 22, 24, 26}, 1, now32)},
+				"bar1": {types.MakeMetricData("bar1", []float64{3.5, 4.5, 5.5, 6.5, 7.5}, 1, now32)},
+				"bar2": {types.MakeMetricData("bar2", []float64{9, 10, 11, 12, 13}, 1, now32)},
 			},
 		},
 		{


### PR DESCRIPTION
This PR fixes an issue in groupByNode in which the function would fail if no callback arg was provided in the query. The callback argument should be option, with the default set to "average".

The definition of groupByNode is as follows:

```
groupByNode(seriesList, nodeNum, callback='average')
Takes a serieslist and maps a callback to subgroups within as defined by a common node

&target=groupByNode(ganglia.by-function.*.*.cpu.load5,2,"sumSeries")
Would return multiple series which are each the result of applying the “sumSeries” function to groups joined on the second node (0 indexed) resulting in a list of targets like

sumSeries(ganglia.by-function.server1.*.cpu.load5),sumSeries(ganglia.by-function.server2.*.cpu.load5),...
Node may be an integer referencing a node in the series name or a string identifying a tag.

This is an alias for using [groupByNodes](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.groupByNodes) with a single node.
```