### PR TITLE
Fix summarize function handling of tags

### DIFF
--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -124,7 +124,7 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			},
 			Tags: helper.CopyTags(arg),
 		}
-		r.Tags["summarize"] = e.Args()[1].StringValue
+		r.Tags["summarize"] = e.Args()[1].StringValue()
 		r.Tags["summarizeFunction"] = summarizeFunction
 
 		t := arg.StartTime // unadjusted

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -124,7 +124,7 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			},
 			Tags: helper.CopyTags(arg),
 		}
-		r.Tags["summarize"] = e.Args()[1]
+		r.Tags["summarize"] = e.Args()[1].StringValue
 		r.Tags["summarizeFunction"] = summarizeFunction
 
 		t := arg.StartTime // unadjusted

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -122,9 +122,9 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 				PathExpression:    name,
 				ConsolidationFunc: arg.ConsolidationFunc,
 			},
-			Tags: arg.Tags,
+			Tags: helper.CopyTags(arg),
 		}
-		r.Tags["summarize"] = fmt.Sprintf("%d", bucketSizeInt32)
+		r.Tags["summarize"] = e.Args()[1]
 		r.Tags["summarizeFunction"] = summarizeFunction
 
 		t := arg.StartTime // unadjusted


### PR DESCRIPTION
This PR fixes a bug in the Summarize function in which the function crashed when no tags existed in the passed in series. There is also a fix to correct the value for the summarize tag that is added.