### PR TITLE
Fix legendValue function so that system parameter is handled

### DIFF
--- a/expr/functions/legendValue/function_test.go
+++ b/expr/functions/legendValue/function_test.go
@@ -57,6 +57,38 @@ func TestFunction(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("metric1 (sum: 15.000000) (avg: 3.000000)",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
 		},
+		{
+			"legendValue(metric1,\"sum\",\"si\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric1 (sum: -40.00K )",
+				[]float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+		},
+		{
+			"legendValue(metric1,\"avg\",\"total\",\"si\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric1 (avg: -8.00K ) (total: -40.00K )",
+				[]float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+		},
+		{
+			"legendValue(metric1,\"sum\",\"binary\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric1 (sum: -39.06Ki )",
+				[]float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+		},
+		{
+			"legendValue(metric1,\"avg\",\"total\",\"binary\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("metric1 (avg: -7.81Ki ) (total: -39.06Ki )",
+				[]float64{0, 10000, 20000, -30000, -40000}, 1, now32)},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -267,3 +267,51 @@ func GetCommonTags(series []*types.MetricData) map[string]string {
 
 	return commonTags
 }
+
+type unitPrefix struct {
+	prefix string
+	size   uint64
+}
+
+const floatEpsilon = 0.00000000001
+
+const (
+	unitSystemBinary = "binary"
+	unitSystemSI     = "si"
+)
+
+var UnitSystems = map[string][]unitPrefix{
+	unitSystemBinary: {
+		{"Pi", 1125899906842624}, // 1024^5
+		{"Ti", 1099511627776},    // 1024^4
+		{"Gi", 1073741824},       // 1024^3
+		{"Mi", 1048576},          // 1024^2
+		{"Ki", 1024},
+	},
+	unitSystemSI: {
+		{"P", 1000000000000000}, // 1000^5
+		{"T", 1000000000000},    // 1000^4
+		{"G", 1000000000},       // 1000^3
+		{"M", 1000000},          // 1000^2
+		{"K", 1000},
+	},
+}
+
+// formatUnits formats the given value according to the given unit prefix system
+func FormatUnits(v float64, system string) (float64, string) {
+	unitsystem := UnitSystems[system]
+	for _, p := range unitsystem {
+		fsize := float64(p.size)
+		if math.Abs(v) >= fsize {
+			v2 := v / fsize
+			if (v2-math.Floor(v2)) < floatEpsilon && v > 1 {
+				v2 = math.Floor(v2)
+			}
+			return v2, p.prefix
+		}
+	}
+	if (v-math.Floor(v)) < floatEpsilon && v > 1 {
+		v = math.Floor(v)
+	}
+	return v, ""
+}


### PR DESCRIPTION
This PR fixes the legendValue function so that the option system parameter is correctly handled. Previously, the system parameter was ignored.

Graphite web's definition of legendValue is as follows: 

```
legendValue(seriesList, *valueTypes)
Takes one metric or a wildcard seriesList and a string in quotes. Appends a value to the metric name in the legend. Currently one or several of: last, avg, total, min, max. The last argument can be si (default) or binary, in that case values will be formatted in the corresponding system.

&target=legendValue(Sales.widgets.largeBlue, 'avg', 'max', 'si')
```