### PR TITLE
Fix series naming in aggregate with wildcards functions

### DIFF
--- a/expr/functions/averageSeriesWithWildcards/function.go
+++ b/expr/functions/averageSeriesWithWildcards/function.go
@@ -2,7 +2,6 @@ package averageSeriesWithWildcards
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strings"
 
@@ -72,12 +71,8 @@ func (f *averageSeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from
 
 	for _, series := range nodeList {
 		args := groups[series]
-		r := *args[0]
-		r.Name = fmt.Sprintf("averageSeriesWithWildcards(%s)", series)
-		r.Tags = make(map[string]string)
-		for k, v := range args[0].Tags {
-			r.Tags[k] = v
-		}
+		r := args[0].CopyLink()
+		r.Name = series
 		r.Tags["name"] = series
 		r.Values = make([]float64, len(args[0].Values))
 
@@ -102,7 +97,7 @@ func (f *averageSeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from
 			}
 		}
 
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/averageSeriesWithWildcards/function_test.go
+++ b/expr/functions/averageSeriesWithWildcards/function_test.go
@@ -38,8 +38,8 @@ func TestAverageSeriesWithWildcards(t *testing.T) {
 			},
 			"averageSeriesWithWildcards",
 			map[string][]*types.MetricData{
-				"averageSeriesWithWildcards(metric1.baz)": {types.MakeMetricData("averageSeriesWithWildcards(metric1.baz)", []float64{6, 7, 8, 9, 10}, 1, now32)},
-				"averageSeriesWithWildcards(metric1.qux)": {types.MakeMetricData("averageSeriesWithWildcards(metric1.qux)", []float64{6.5, 7.5, 8.5, 9.5, 10.5}, 1, now32)},
+				"metric1.baz": {types.MakeMetricData("metric1.baz", []float64{6, 7, 8, 9, 10}, 1, now32)},
+				"metric1.qux": {types.MakeMetricData("metric1.qux", []float64{6.5, 7.5, 8.5, 9.5, 10.5}, 1, now32)},
 			},
 		},
 	}

--- a/expr/functions/multiplySeriesWithWildcards/function.go
+++ b/expr/functions/multiplySeriesWithWildcards/function.go
@@ -2,7 +2,6 @@ package multiplySeriesWithWildcards
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strings"
 
@@ -76,7 +75,7 @@ func (f *multiplySeriesWithWildcards) Do(ctx context.Context, e parser.Expr, fro
 	for _, series := range nodeList {
 		args := groups[series]
 		r := args[0].CopyLink()
-		r.Name = fmt.Sprintf("multiplySeriesWithWildcards(%s)", series)
+		r.Name = series
 		r.Tags = make(map[string]string)
 		for k, v := range args[0].Tags {
 			r.Tags[k] = v

--- a/expr/functions/multiplySeriesWithWildcards/function_test.go
+++ b/expr/functions/multiplySeriesWithWildcards/function_test.go
@@ -38,8 +38,8 @@ func TestFunctionMultiReturn(t *testing.T) {
 			},
 			"multiplySeriesWithWildcards",
 			map[string][]*types.MetricData{
-				"multiplySeriesWithWildcards(metric1.baz)": {types.MakeMetricData("multiplySeriesWithWildcards(metric1.baz)", []float64{22, 48, 78, 112, 150}, 1, now32)},
-				"multiplySeriesWithWildcards(metric1.qux)": {types.MakeMetricData("multiplySeriesWithWildcards(metric1.qux)", []float64{42, 0, 72, 90, 110}, 1, now32)},
+				"metric1.baz": {types.MakeMetricData("metric1.baz", []float64{22, 48, 78, 112, 150}, 1, now32)},
+				"metric1.qux": {types.MakeMetricData("metric1.qux", []float64{42, 0, 72, 90, 110}, 1, now32)},
 			},
 		},
 	}

--- a/expr/functions/sumSeriesWithWildcards/function.go
+++ b/expr/functions/sumSeriesWithWildcards/function.go
@@ -2,7 +2,6 @@ package sumSeriesWithWildcards
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strings"
 
@@ -72,12 +71,8 @@ func (f *sumSeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from, un
 
 	for _, series := range nodeList {
 		args := groups[series]
-		r := *args[0]
-		r.Name = fmt.Sprintf("sumSeriesWithWildcards(%s)", series)
-		r.Tags = make(map[string]string)
-		for k, v := range args[0].Tags {
-			r.Tags[k] = v
-		}
+		r := args[0].CopyLink()
+		r.Name = series
 		r.Tags["name"] = series
 		r.Values = make([]float64, len(args[0].Values))
 
@@ -98,7 +93,7 @@ func (f *sumSeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from, un
 			}
 		}
 
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }

--- a/expr/functions/sumSeriesWithWildcards/function_test.go
+++ b/expr/functions/sumSeriesWithWildcards/function_test.go
@@ -37,8 +37,8 @@ func TestFunctionMultiReturn(t *testing.T) {
 			},
 			"sumSeriesWithWildcards",
 			map[string][]*types.MetricData{
-				"sumSeriesWithWildcards(metric1.baz)": {types.MakeMetricData("sumSeriesWithWildcards(metric1.baz)", []float64{12, 14, 16, 18, 20}, 1, now32)},
-				"sumSeriesWithWildcards(metric1.qux)": {types.MakeMetricData("sumSeriesWithWildcards(metric1.qux)", []float64{13, 15, 17, 19, 21}, 1, now32)},
+				"metric1.baz": {types.MakeMetricData("metric1.baz", []float64{12, 14, 16, 18, 20}, 1, now32)},
+				"metric1.qux": {types.MakeMetricData("metric1.qux", []float64{13, 15, 17, 19, 21}, 1, now32)},
 			},
 		},
 	}


### PR DESCRIPTION
CarbonAPI is naming the target sumSeriesWithWildcards(series) and MT is naming it just "series". 

We fix it to match MT because that's also what graphite web does: https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L513