### PR TITLE
Add support for Graphite web sinFunction

### DIFF
--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -84,6 +84,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/scaleToSeconds"
 	"github.com/grafana/carbonapi/expr/functions/seriesByTag"
 	"github.com/grafana/carbonapi/expr/functions/seriesList"
+	"github.com/grafana/carbonapi/expr/functions/sinFunction"
 	"github.com/grafana/carbonapi/expr/functions/slo"
 	"github.com/grafana/carbonapi/expr/functions/smartSummarize"
 	"github.com/grafana/carbonapi/expr/functions/sortBy"
@@ -195,6 +196,7 @@ func New(configs map[string]string) {
 		{name: "scaleToSeconds", filename: "scaleToSeconds", order: scaleToSeconds.GetOrder(), f: scaleToSeconds.New},
 		{name: "seriesByTag", filename: "seriesByTag", order: seriesByTag.GetOrder(), f: seriesByTag.New},
 		{name: "seriesList", filename: "seriesList", order: seriesList.GetOrder(), f: seriesList.New},
+		{name: "sinFunction", filename: "sinFunction", order: sinFunction.GetOrder(), f: sinFunction.New},
 		{name: "slo", filename: "slo", order: slo.GetOrder(), f: slo.New},
 		{name: "smartSummarize", filename: "smartSummarize", order: smartSummarize.GetOrder(), f: smartSummarize.New},
 		{name: "sortBy", filename: "sortBy", order: sortBy.GetOrder(), f: sortBy.New},

--- a/expr/functions/sinFunction/function.go
+++ b/expr/functions/sinFunction/function.go
@@ -1,0 +1,109 @@
+package sinFunction
+
+import (
+	"context"
+	"math"
+
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+)
+
+type sinFunction struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &sinFunction{}
+	functions := []string{"sinFunction", "sin"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// sinFunction(name, amplitude, step)
+func (f *sinFunction) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	name, err := e.GetStringArg(0)
+	if err != nil {
+		return nil, err
+	}
+
+	var amplitude = 1.0
+	var stepInt = 60
+	if len(e.Args()) >= 2 {
+		amplitude, err = e.GetFloatArgDefault(1, 1.0)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(e.Args()) == 3 {
+		stepInt, err = e.GetIntArgDefault(2, 60)
+		if err != nil {
+			return nil, err
+		}
+	}
+	step := int64(stepInt)
+
+	newValues := make([]float64, (until-from-1+step)/step)
+	value := from
+	for i := 0; i < len(newValues); i++ {
+		newValues[i] = math.Sin(float64(value)) * amplitude
+		value += step
+	}
+
+	r := types.MetricData{
+		FetchResponse: pb.FetchResponse{
+			Name:              name,
+			Values:            newValues,
+			StepTime:          step,
+			StartTime:         from,
+			StopTime:          until,
+			ConsolidationFunc: "sin",
+		},
+		Tags: map[string]string{"name": name},
+	}
+
+	return []*types.MetricData{&r}, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *sinFunction) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"sinFunction": {
+			Description: "Just returns the sine of the current time. The optional amplitude parameter changes the amplitude of the wave.\n" +
+				"Example:\n\n.. code-block:: none\n\n &target=sin(\"The.time.series\", 2)\n\n" +
+				"This would create a series named “The.time.series” that contains sin(x)*2. Accepts optional second argument as ‘amplitude’ parameter (default amplitude is 1)\n Accepts optional third argument as ‘step’ parameter (default step is 60 sec)\n\n" +
+				"Alias: sin",
+			Function: "sinFunction(name, amplitude=1, step=60)",
+			Group:    "Transform",
+			Module:   "graphite.render.functions",
+			Name:     "scale",
+			Params: []types.FunctionParam{
+				{
+					Name:     "name",
+					Required: true,
+					Type:     types.String,
+				},
+				{
+					Name:     "amplitude",
+					Required: false,
+					Type:     types.Integer,
+					Default:  types.NewSuggestion(1),
+				},
+				{
+					Name:     "step",
+					Required: false,
+					Type:     types.Integer,
+					Default:  types.NewSuggestion(60),
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/sinFunction/function.go
+++ b/expr/functions/sinFunction/function.go
@@ -60,12 +60,11 @@ func (f *sinFunction) Do(ctx context.Context, e parser.Expr, from, until int64, 
 
 	r := types.MetricData{
 		FetchResponse: pb.FetchResponse{
-			Name:              name,
-			Values:            newValues,
-			StepTime:          step,
-			StartTime:         from,
-			StopTime:          until,
-			ConsolidationFunc: "sin",
+			Name:      name,
+			Values:    newValues,
+			StepTime:  step,
+			StartTime: from,
+			StopTime:  until,
 		},
 		Tags: map[string]string{"name": name},
 	}

--- a/expr/functions/sinFunction/function_test.go
+++ b/expr/functions/sinFunction/function_test.go
@@ -1,0 +1,55 @@
+package sinFunction
+
+import (
+	"testing"
+
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/metadata"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+	th "github.com/grafana/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestSinFunction(t *testing.T) {
+	var startTime int64 = 1
+
+	tests := []th.EvalTestItemWithRange{
+		{
+			Target: `sinFunction("The.time.series")`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{From: startTime, Until: startTime + 240}: {},
+			},
+			Want: []*types.MetricData{types.MakeMetricData("The.time.series",
+				[]float64{0.8414709848078965, -0.9661177700083929, 0.9988152247235795, -0.936451400117644}, 60, startTime)},
+			From:  startTime,
+			Until: startTime + 240,
+		},
+		{
+			Target: `sinFunction("The.time.series.2", 5.0, 10)`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{From: startTime, Until: startTime + 60}: {},
+			},
+			Want: []*types.MetricData{types.MakeMetricData("The.time.series.2",
+				[]float64{4.207354924039483, -4.9999510327535175, 4.18327819268028, -2.0201882266153253, -0.7931133440235449, 3.3511458792168733}, 10, startTime)},
+			From:  startTime,
+			Until: startTime + 60,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for the Graphite web sinFunction. The description of sinFunction is as follows:

```
sinFunction(name, amplitude=1, step=60)
Short Alias: sin()

Just returns the sine of the current time. The optional amplitude parameter changes the amplitude of the wave.

Example:

&target=sin("The.time.series", 2)
This would create a series named “The.time.series” that contains sin(x)*2. Accepts optional second argument as ‘amplitude’ parameter (default amplitude is 1) Accepts optional third argument as ‘step’ parameter (default step is 60 sec)
```