### PR TITLE
Add support for optional parameters for linearRegression

### DIFF
--- a/expr/functions/linearRegression/function.go
+++ b/expr/functions/linearRegression/function.go
@@ -38,16 +38,32 @@ func (f *linearRegression) Do(ctx context.Context, e parser.Expr, from, until in
 		return nil, err
 	}
 
+	var startSourceAt int32
+	var endSourceAt int32
+	if len(e.Args()) >= 2 {
+		startSourceAt, err = e.GetIntervalArg(1, -1)
+		if err != nil {
+			return nil, err
+		}
+		if len(e.Args()) == 3 {
+			endSourceAt, err = e.GetIntervalArg(2, -1)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	degree := 1
-
 	var results []*types.MetricData
-
 	for _, a := range arg {
 		r := a.CopyLink()
 		if len(e.Args()) > 2 {
 			r.Name = fmt.Sprintf("linearRegression(%s,'%s','%s')", a.GetName(), e.Args()[1].StringValue(), e.Args()[2].StringValue())
+			r.StartTime += int64(startSourceAt)
+			r.StopTime += int64(endSourceAt)
 		} else if len(e.Args()) > 1 {
-			r.Name = fmt.Sprintf("linearRegression(%s,'%s')", a.GetName(), e.Args()[2].StringValue())
+			r.Name = fmt.Sprintf("linearRegression(%s,'%s')", a.GetName(), e.Args()[1].StringValue())
+			r.StartTime += int64(startSourceAt)
 		} else {
 			r.Name = fmt.Sprintf("linearRegression(%s)", a.GetName())
 		}
@@ -111,12 +127,34 @@ func (f *linearRegression) Description() map[string]types.FunctionDescription {
 					Type:     types.SeriesList,
 				},
 				{
-					Name: "startSourceAt",
-					Type: types.Date,
+					Name:     "startSourceAt",
+					Required: false,
+					Suggestions: types.NewSuggestions(
+						"1h",
+						"6h",
+						"12h",
+						"1d",
+						"2d",
+						"7d",
+						"14d",
+						"30d",
+					),
+					Type: types.Interval,
 				},
 				{
-					Name: "endSourceAt",
-					Type: types.Date,
+					Name:     "endSourceAt",
+					Required: false,
+					Suggestions: types.NewSuggestions(
+						"1h",
+						"6h",
+						"12h",
+						"1d",
+						"2d",
+						"7d",
+						"14d",
+						"30d",
+					),
+					Type: types.Interval,
 				},
 			},
 		},

--- a/expr/functions/linearRegression/function_test.go
+++ b/expr/functions/linearRegression/function_test.go
@@ -39,6 +39,32 @@ func TestFunction(t *testing.T) {
 					[]float64{1, 2, 3, 4, 5, 6}, 1, now32),
 			},
 		},
+		{
+			"linearRegression(metric1,'1h')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {
+					types.MakeMetricData("metric1",
+						[]float64{1, 2, math.NaN(), math.NaN(), 5, 6}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("linearRegression(metric1,'1h')",
+					[]float64{1, 2, 3, 4, 5, 6}, 1, now32-3600),
+			},
+		},
+		{
+			"linearRegression(metric1,'1h','1m')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {
+					types.MakeMetricData("metric1",
+						[]float64{1, 2, math.NaN(), math.NaN(), 5, 6}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("linearRegression(metric1,'1h','1m')",
+					[]float64{1, 2, 3, 4, 5, 6}, 1, now32-3600),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds support for previously unsupported optional parameters "startSourceAt" and "endSourceAt" for the Graphite web linearRegression function. 

The definition of linearRegression is as follows: 

```
linearRegression(seriesList, startSourceAt=None, endSourceAt=None)
Graphs the linear regression function by least squares method.

Takes one metric or a wildcard seriesList, followed by a quoted string with the time to start the line and another quoted string with the time to end the line. The start and end times are inclusive (default range is from to until). See from / until in the [Render API](https://graphite.readthedocs.io/en/latest/render_api.html) for examples of time formats. Datapoints in the range is used to regression.

Example:

&target=linearRegression(Server.instance01.threads.busy, '-1d')
&target=linearRegression(Server.instance*.threads.busy, "00:00 20140101","11:59 20140630")
```

Note: At this time, only interval arguments such as '1d' are accepted. Absolute time formats will be supported at a later time. 