### PR TITLE
Cedwards/add identity function

### DIFF
--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -46,6 +46,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/holtWintersAberration"
 	"github.com/grafana/carbonapi/expr/functions/holtWintersConfidenceBands"
 	"github.com/grafana/carbonapi/expr/functions/holtWintersForecast"
+	"github.com/grafana/carbonapi/expr/functions/identity"
 	"github.com/grafana/carbonapi/expr/functions/ifft"
 	"github.com/grafana/carbonapi/expr/functions/integral"
 	"github.com/grafana/carbonapi/expr/functions/integralByInterval"
@@ -162,6 +163,7 @@ func New(configs map[string]string) {
 		{name: "holtWintersAberration", filename: "holtWintersAberration", order: holtWintersAberration.GetOrder(), f: holtWintersAberration.New},
 		{name: "holtWintersConfidenceBands", filename: "holtWintersConfidenceBands", order: holtWintersConfidenceBands.GetOrder(), f: holtWintersConfidenceBands.New},
 		{name: "holtWintersForecast", filename: "holtWintersForecast", order: holtWintersForecast.GetOrder(), f: holtWintersForecast.New},
+		{name: "identity", filename: "identity", order: identity.GetOrder(), f: identity.New},
 		{name: "ifft", filename: "ifft", order: ifft.GetOrder(), f: ifft.New},
 		{name: "integral", filename: "integral", order: integral.GetOrder(), f: integral.New},
 		{name: "integralByInterval", filename: "integralByInterval", order: integralByInterval.GetOrder(), f: integralByInterval.New},

--- a/expr/functions/identity/function.go
+++ b/expr/functions/identity/function.go
@@ -1,0 +1,81 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+)
+
+type identity struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &identity{}
+	functions := []string{"identity"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// identity(name)
+func (f *identity) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	name, err := e.GetStringArg(0)
+	if err != nil {
+		return nil, err
+	}
+
+	step := int64(60)
+
+	newValues := make([]float64, (until-from-1+step)/step)
+	value := from
+	for i := 0; i < len(newValues); i++ {
+		newValues[i] = float64(value)
+		value += step
+	}
+
+	p := types.MetricData{
+		FetchResponse: pb.FetchResponse{
+			Name:              fmt.Sprintf("identity(%s)", name),
+			StartTime:         from,
+			StopTime:          until,
+			StepTime:          step,
+			Values:            newValues,
+			ConsolidationFunc: "max",
+		},
+		Tags: map[string]string{"name": name},
+	}
+
+	return []*types.MetricData{&p}, nil
+
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *identity) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"identity": {
+			Description: "Identity function: Returns datapoints where the value equals the timestamp of the datapoint.\n Useful when you have another series where the value is a timestamp, and you want to compare it to the time of the datapoint, to render an age\n\nExample:\n\n.. code-block:: none\n\n  &target=identity(\"The.time.series\")\n This would create a series named “The.time.series” that contains points where x(t) == t.)",
+			Function:    "identity(name)",
+			Group:       "Calculate",
+			Module:      "graphite.render.functions",
+			Name:        "identity",
+			Params: []types.FunctionParam{
+				{
+					Name:     "name",
+					Required: true,
+					Type:     types.String,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/identity/function_test.go
+++ b/expr/functions/identity/function_test.go
@@ -1,0 +1,45 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/metadata"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+	th "github.com/grafana/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestIdentityFunction(t *testing.T) {
+	var startTime int64 = 0
+
+	tests := []th.EvalTestItemWithRange{
+		{
+			Target: `identity("The.time.series")`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{From: startTime, Until: startTime + 240}: {},
+			},
+			Want: []*types.MetricData{types.MakeMetricData("identity(The.time.series)",
+				[]float64{0, 60, 120, 180}, 60, startTime)},
+			From:  startTime,
+			Until: startTime + 240,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for the Graphite web identity() function. The description of this function is: 

```
identity(name)
Identity function: Returns datapoints where the value equals the timestamp of the datapoint. Useful when you have another series where the value is a timestamp, and you want to compare it to the time of the datapoint, to render an age

Example:

&target=identity("The.time.series")
This would create a series named “The.time.series” that contains points where x(t) == t.
```

The Graphite web implementation of this function can be found [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L4866)