### PR TITLE
Add aggregateSeriesLists function

### DIFF
--- a/expr/consolidations/consolidations.go
+++ b/expr/consolidations/consolidations.go
@@ -195,11 +195,14 @@ func SummarizeValues(f string, values []float64, XFilesFactor float32) float64 {
 		rv = Percentile(values, 50, true)
 		total = notNans(values)
 	case "multiply":
-		rv = values[0]
-		for _, av := range values[1:] {
-			if !math.IsNaN(av) {
+		rv = 1.0
+		for _, v := range values {
+			if math.IsNaN(v) {
+				rv = math.NaN()
+				break
+			} else {
 				total++
-				rv *= av
+				rv *= v
 			}
 		}
 	case "diff":
@@ -375,19 +378,30 @@ func AggCount(v []float64) float64 {
 	return float64(n)
 }
 
-// AggCount counts non-NaN points
 func AggDiff(v []float64) float64 {
-	res := v[0]
-	if len(v) == 1 {
-		return res
-	}
-	for _, vv := range v[1:] {
+	safeValues := make([]float64, 0)
+	for _, vv := range v {
 		if !math.IsNaN(vv) {
-			res -= vv
+			safeValues = append(safeValues, vv)
 		}
 	}
 
-	return res
+	if len(safeValues) > 0 {
+		res := safeValues[0]
+		if len(safeValues) == 1 {
+			return res
+		}
+
+		for _, vv := range safeValues[1:] {
+			if !math.IsNaN(vv) {
+				res -= vv
+			}
+		}
+
+		return res
+	} else {
+		return math.NaN()
+	}
 }
 
 // MaxValue returns maximum from the list

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -132,7 +132,7 @@ func TestAverageSeries(t *testing.T) {
 				},
 			},
 			[]*types.MetricData{types.MakeMetricData("multiplySeries(metric[123])",
-				[]float64{6, math.NaN(), 24, 15, 120, 30}, 1, now32)},
+				[]float64{6, math.NaN(), 24, math.NaN(), 120, math.NaN()}, 1, now32)},
 		},
 		{
 			`aggregate(metric[123], "range")`,

--- a/expr/functions/aggregateSeriesLists/function.go
+++ b/expr/functions/aggregateSeriesLists/function.go
@@ -38,6 +38,12 @@ func (f *aggregateSeriesLists) Do(ctx context.Context, e parser.Expr, from, unti
 		return nil, err
 	}
 
+	if len(seriesList1) != len(seriesList2) {
+		return nil, fmt.Errorf("seriesListFirstPos and seriesListSecondPos must have equal length")
+	} else if len(seriesList1) == 0 {
+		return make([]*types.MetricData, 0, 0), nil
+	}
+
 	aggFuncStr, err := e.GetStringArg(2)
 	if err != nil {
 		return nil, err
@@ -47,13 +53,9 @@ func (f *aggregateSeriesLists) Do(ctx context.Context, e parser.Expr, from, unti
 		return nil, fmt.Errorf("unsupported consolidation function %s", aggFuncStr)
 	}
 
-	xFilesFactor, err := e.GetFloatArg(3)
+	xFilesFactor, err := e.GetFloatArgDefault(3, float64(seriesList1[0].XFilesFactor))
 	if err != nil {
 		return nil, err
-	}
-
-	if len(seriesList1) != len(seriesList2) {
-		return nil, fmt.Errorf("seriesListFirstPos and seriesListSecondPos must have equal length")
 	}
 
 	results := make([]*types.MetricData, 0, len(seriesList1))

--- a/expr/functions/aggregateSeriesLists/function.go
+++ b/expr/functions/aggregateSeriesLists/function.go
@@ -1,0 +1,107 @@
+package aggregateSeriesLists
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/carbonapi/expr/consolidations"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+)
+
+type aggregateSeriesLists struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(_ string) []interfaces.FunctionMetadata {
+	f := &aggregateSeriesLists{}
+	res := make([]interfaces.FunctionMetadata, 0)
+	for _, n := range []string{"aggregateSeriesLists"} {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+func (f *aggregateSeriesLists) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	seriesList1, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+	seriesList2, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	aggFuncStr, err := e.GetStringArg(2)
+	if err != nil {
+		return nil, err
+	}
+	aggFunc, ok := consolidations.ConsolidationToFunc[aggFuncStr]
+	if !ok {
+		return nil, fmt.Errorf("unsupported consolidation function %s", aggFuncStr)
+	}
+
+	xFilesFactor, err := e.GetFloatArg(3)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(seriesList1) != len(seriesList2) {
+		return nil, fmt.Errorf("seriesListFirstPos and seriesListSecondPos must have equal length")
+	}
+
+	results := make([]*types.MetricData, 0, len(seriesList1))
+
+	for i, series1 := range seriesList1 {
+		series2 := seriesList2[i]
+
+		r, err := helper.AggregateSeries(e, []*types.MetricData{series1.CopyLink(), series2.CopyLink()}, aggFunc, xFilesFactor)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, r[0])
+	}
+
+	return results, nil
+}
+
+func (f *aggregateSeriesLists) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"aggregateSeriesLists": {
+			Name:        "aggregateSeriesLists",
+			Function:    "aggregateSeriesLists(seriesListFirstPos, seriesListSecondPos, func, xFilesFactor=None)",
+			Description: "Iterates over a two lists and aggregates using specified function list1[0] to list2[0], list1[1] to list2[1] and so on. The lists will need to be the same length.",
+			Module:      "graphite.render.functions",
+			Group:       "Combine",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesListFirstPos",
+					Type:     types.SeriesList,
+					Required: true,
+				},
+				{
+					Name:     "seriesListSecondPos",
+					Type:     types.SeriesList,
+					Required: true,
+				},
+				{
+					Name:     "func",
+					Type:     types.AggFunc,
+					Required: true,
+				},
+				{
+					Name:     "xFilesFactor",
+					Type:     types.Float,
+					Required: false,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/aggregateSeriesLists/function_test.go
+++ b/expr/functions/aggregateSeriesLists/function_test.go
@@ -1,0 +1,127 @@
+package aggregateSeriesLists
+
+import (
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/metadata"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+	th "github.com/grafana/carbonapi/tests"
+	"math"
+	"testing"
+	"time"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+var (
+	now     = time.Now().Unix()
+	shipped = []*types.MetricData{
+		types.MakeMetricData("mining.other.shipped", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
+		types.MakeMetricData("mining.diamond.shipped", []float64{0, -1, -1, 2, 3, -5, -8, 13, 21, -34, -55, 89, 144, -233, -377}, 1, now),
+		types.MakeMetricData("mining.graphite.shipped", []float64{math.NaN(), 2.3, math.NaN(), -4.5, math.NaN(), 6.7, math.NaN(), -8.9, math.NaN(), 10.111, math.NaN(), -12.13, math.NaN(), 14.15, math.NaN(), -16.17, math.NaN(), 18.19, math.NaN(), -20.21}, 1, now),
+		types.MakeMetricData("mining.carbon.shipped", []float64{3.141, math.NaN(), 2.718, 6.022, 6.674, math.NaN(), 6.626, 1.602, 2.067, 9.274, math.NaN(), 5.555}, 1, now),
+	}
+	extracted = []*types.MetricData{
+		types.MakeMetricData("mining.other.extracted", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
+		types.MakeMetricData("mining.diamond.extracted", []float64{0, 1, -1, 2, -3, 5, -8, 13, -21, 34, -55, 89, -144, 233, -377}, 1, now),
+		types.MakeMetricData("mining.graphite.extracted", []float64{math.NaN(), 9, 8, math.NaN(), 6, math.NaN(), 4, 3, 2, math.NaN(), 0, -1, math.NaN(), -3, -4, -5, math.NaN(), math.NaN(), -8, -9, -10}, 1, now),
+		types.MakeMetricData("mining.carbon.extracted", []float64{7.22, math.NaN(), 2.718, math.NaN(), 2.54, -1.234, -6.16, -13.37, math.NaN(), -7.77, 0.128, 8.912}, 1, now),
+	}
+)
+
+func TestFunction(t *testing.T) {
+	tests := []th.EvalTestItem{
+		{
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\",-1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"mining.*.shipped", 0, 1}:   shipped,
+				{"mining.*.extracted", 0, 1}: extracted,
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\",-1)", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\",-1)", []float64{0.0, 0.0, -1.0, 2.0, 0.0, 0.0, -8.0, 13.0, 0.0, 0.0, -55.0, 89.0, 0.0, 0.0, -377.0}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\",-1)", []float64{math.NaN(), 5.65, 8.0, -4.5, 6.0, 6.7, 4.0, -2.95, 2.0, 10.111, 0.0, -6.565, math.NaN(), 5.575, -4.0, -10.585, math.NaN(), 18.19, -8.0, -14.605, -10.0}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"avg\",-1)", []float64{5.1805, math.NaN(), 2.718, 6.022, 4.607, -1.234, 0.2330000000000001, -5.8839999999999995, 2.067, 0.7519999999999998, 0.128, 7.2335}, 1, now),
+			},
+		},
+		{
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\",-1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"mining.*.shipped", 0, 1}:   shipped,
+				{"mining.*.extracted", 0, 1}: extracted,
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\",-1)", []float64{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\",-1)", []float64{0, 0, -2, 4, 0, 0, -16, 26, 0, 0, -110, 178, 0, 0, -754}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\",-1)", []float64{math.NaN(), 11.3, 8, -4.5, 6, 6.7, 4, -5.9, 2, 10.111, 0, -13.13, math.NaN(), 11.15, -4, -21.17, math.NaN(), 18.19, -8, -29.21, -10}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"sum\",-1)", []float64{10.361, math.NaN(), 5.436, 6.022, 9.214, -1.234, 0.4660000000000002, -11.767999999999999, 2.067, 1.5039999999999996, 0.128, 14.467}, 1, now),
+			},
+		},
+		{
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\",-1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"mining.*.shipped", 0, 1}:   shipped,
+				{"mining.*.extracted", 0, 1}: extracted,
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\",-1)", []float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\",-1)", []float64{0, -2, 0, 0, 6, -10, 0, 0, 42, -68, 0, 0, 288, -466, 0}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\",-1)", []float64{math.NaN(), -6.7, 8, -4.5, 6, 6.7, 4, -11.9, 2, 10.111, 0, -11.13, math.NaN(), 17.15, -4, -11.170000000000002, math.NaN(), 18.19, -8, -11.21, -10}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"diff\",-1)", []float64{-4.079, math.NaN(), 0.0, 6.022, 4.134, -1.234, 12.786000000000001, 14.972, 2.067, 17.043999999999997, 0.128, -3.357000000000001}, 1, now),
+			},
+		},
+		{
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\",-1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"mining.*.shipped", 0, 1}:   shipped,
+				{"mining.*.extracted", 0, 1}: extracted,
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\",-1)", []float64{1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225, 256, 289, 324, 361, 400}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\",-1)", []float64{0, -1, 1, 4, -9, -25, 64, 169, -441, -1156, 3025, 7921, -20736, -54289, 142129}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\",-1)", []float64{math.NaN(), 20.7, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), -26.7, math.NaN(), math.NaN(), math.NaN(), 12.13, math.NaN(), -42.45, math.NaN(), 80.85, math.NaN(), math.NaN(), math.NaN(), 181.89, math.NaN()}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"multiply\",-1)", []float64{22.67802, math.NaN(), 7.387524, math.NaN(), 16.95196, math.NaN(), -40.81616, -21.41874, math.NaN(), -72.05897999999999, math.NaN(), 49.50616}, 1, now),
+			},
+		},
+		{
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\",-1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"mining.*.shipped", 0, 1}:   shipped,
+				{"mining.*.extracted", 0, 1}: extracted,
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\",-1)", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\",-1)", []float64{0, 1, -1, 2, 3, 5, -8, 13, 21, 34, -55, 89, 144, 233, -377}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\",-1)", []float64{math.NaN(), 9, 8, -4.5, 6, 6.7, 4, 3, 2, 10.111, 0, -1, math.NaN(), 14.15, -4, -5, math.NaN(), 18.19, -8, -9, -10}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"max\",-1)", []float64{7.22, math.NaN(), 2.718, 6.022, 6.674, -1.234, 6.626, 1.602, 2.067, 9.274, 0.128, 8.912}, 1, now),
+			},
+		},
+		{
+			"aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\",-1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"mining.*.shipped", 0, 1}:   shipped,
+				{"mining.*.extracted", 0, 1}: extracted,
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\",-1)", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\",-1)", []float64{0, -1, -1, 2, -3, -5, -8, 13, -21, -34, -55, 89, -144, -233, -377}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\",-1)", []float64{math.NaN(), 2.3, 8, -4.5, 6, 6.7, 4, -8.9, 2, 10.111, 0, -12.13, math.NaN(), -3, -4, -16.17, math.NaN(), 18.19, -8, -20.21, -10}, 1, now),
+				types.MakeMetricData("aggregateSeriesLists(mining.*.shipped, mining.*.extracted,\"min\",-1)", []float64{3.141, math.NaN(), 2.718, 6.022, 2.54, -1.234, -6.16, -13.37, 2.067, -7.77, 0.128, 5.555}, 1, now),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Target, func(t *testing.T) {
+			th.TestEvalExpr(t, &test)
+		})
+	}
+}

--- a/expr/functions/aggregateWithWildcards/function_test.go
+++ b/expr/functions/aggregateWithWildcards/function_test.go
@@ -108,7 +108,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 				},
 			},
 			[]*types.MetricData{
-				types.MakeMetricData("metric1.baz", []float64{2, math.NaN(), 6, 3, 20, 30}, 1, now32),
+				types.MakeMetricData("metric1.baz", []float64{2, math.NaN(), 6, math.NaN(), 20, 30}, 1, now32),
 				types.MakeMetricData("metric1.qux", []float64{12, math.NaN(), 20, 30, 42, math.NaN()}, 1, now32),
 			},
 		},

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -1,13 +1,13 @@
 package functions
 
 import (
-	"github.com/grafana/carbonapi/expr/functions/powSeries"
 	"sort"
 	"strings"
 
 	"github.com/grafana/carbonapi/expr/functions/absolute"
 	"github.com/grafana/carbonapi/expr/functions/aggregate"
 	"github.com/grafana/carbonapi/expr/functions/aggregateLine"
+	"github.com/grafana/carbonapi/expr/functions/aggregateSeriesLists"
 	"github.com/grafana/carbonapi/expr/functions/aggregateWithWildcards"
 	"github.com/grafana/carbonapi/expr/functions/alias"
 	"github.com/grafana/carbonapi/expr/functions/aliasByBase64"
@@ -77,6 +77,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/percentileOfSeries"
 	"github.com/grafana/carbonapi/expr/functions/polyfit"
 	"github.com/grafana/carbonapi/expr/functions/pow"
+	"github.com/grafana/carbonapi/expr/functions/powSeries"
 	"github.com/grafana/carbonapi/expr/functions/randomWalk"
 	"github.com/grafana/carbonapi/expr/functions/rangeOfSeries"
 	"github.com/grafana/carbonapi/expr/functions/reduce"
@@ -124,6 +125,7 @@ func New(configs map[string]string) {
 		{name: "absolute", filename: "absolute", order: absolute.GetOrder(), f: absolute.New},
 		{name: "aggregate", filename: "aggregate", order: aggregate.GetOrder(), f: aggregate.New},
 		{name: "aggregateLine", filename: "aggregateLine", order: aggregateLine.GetOrder(), f: aggregateLine.New},
+		{name: "aggregateSeriesLists", filename: "aggregateSeriesLists", order: aggregateSeriesLists.GetOrder(), f: aggregateSeriesLists.New},
 		{name: "aggregateWithWildcards", filename: "aggregateWithWildcards", order: aggregateWithWildcards.GetOrder(), f: aggregateWithWildcards.New},
 		{name: "alias", filename: "alias", order: alias.GetOrder(), f: alias.New},
 		{name: "aliasByBase64", filename: "aliasByBase64", order: aliasByBase64.GetOrder(), f: aliasByBase64.New},


### PR DESCRIPTION
This PR implements the `aggregateSeriesLists` function.

Doc: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.aggregateSeriesLists
Python implementation: https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L264-L307

This PR also alters the implementation of the diff and multiply aggregation functions (I believe bringing it it more in-line with what the Python implementation does).

In particular, the Python implementation of multiply returns `math.NaN()` if any of the inputs are `math.NaN()` ([link](https://github.com/graphite-project/graphite-web/blob/2ec4b6cf25b3d71bead44579b8a6d19f2c83bae5/webapp/graphite/functions/safe.py#L50-L51)).

Also, the Python implementation of diff ignores all `math.NaN()` values ([link](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/functions/safe.py#L15)).