### PR TITLE
Fix out of range panics for empty input series

### DIFF
--- a/expr/functions/aggregate/function.go
+++ b/expr/functions/aggregate/function.go
@@ -52,6 +52,9 @@ func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			if err != nil {
 				return nil, err
 			}
+			if len(args) == 0 {
+				return []*types.MetricData{}, nil
+			}
 			callback = strings.Replace(e.Target(), "Series", "", 1)
 			isAggregateFunc = false
 			xFilesFactor = -1 // xFilesFactor is not used by the ...Series functions
@@ -61,12 +64,13 @@ func (f *aggregate) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		if err != nil {
 			return nil, err
 		}
-		if len(e.Args()) == 3 {
-			xFilesFactor, err = e.GetFloatArgDefault(2, float64(args[0].XFilesFactor)) // If set by setXFilesFactor, all series in a list will have the same value
+		if len(args) == 0 {
+			return []*types.MetricData{}, nil
+		}
 
-			if err != nil {
-				return nil, err
-			}
+		xFilesFactor, err = e.GetFloatArgDefault(2, float64(args[0].XFilesFactor)) // If set by setXFilesFactor, all series in a list will have the same value
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -29,6 +29,18 @@ func TestAverageSeries(t *testing.T) {
 		{
 			`aggregate(metric[123], "avg")`,
 			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {},
+			},
+			[]*types.MetricData{},
+		},
+		{
+			`aggregate(metric[123], "avg")`,
+			map[parser.MetricRequest][]*types.MetricData{},
+			[]*types.MetricData{},
+		},
+		{
+			`aggregate(metric[123], "avg")`,
+			map[parser.MetricRequest][]*types.MetricData{
 				{"metric[123]", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),

--- a/expr/functions/hitcount/function.go
+++ b/expr/functions/hitcount/function.go
@@ -38,6 +38,10 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 		return nil, err
 	}
 
+	if len(args) == 0 {
+		return []*types.MetricData{}, nil
+	}
+
 	bucketSizeInt32, err := e.GetIntervalArg(1, 1)
 	if err != nil {
 		return nil, err

--- a/expr/functions/hitcount/function_test.go
+++ b/expr/functions/hitcount/function_test.go
@@ -20,6 +20,24 @@ func init() {
 		metadata.RegisterFunction(m.Name, m.F)
 	}
 }
+func TestHitcountEmptyData(t *testing.T) {
+	tests := []th.EvalTestItem{
+		{
+			"hitcount(foo.bar, '1min')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"foo.bar", 0, 1}: {},
+			},
+			[]*types.MetricData{},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}
 
 func TestHitcount(t *testing.T) {
 	_, tenFiftyNine, tenThirty := th.InitTestSummarize()

--- a/expr/functions/multiplySeriesWithWildcards/function_test.go
+++ b/expr/functions/multiplySeriesWithWildcards/function_test.go
@@ -52,3 +52,22 @@ func TestFunctionMultiReturn(t *testing.T) {
 	}
 
 }
+
+func TestEmptyData(t *testing.T) {
+	tests := []th.EvalTestItem{
+		{
+			"multiplySeriesWithWildcards(metric1.foo.*.*,1,2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.*.*", 0, 1}: {},
+			},
+			[]*types.MetricData{},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+}

--- a/expr/functions/percentileOfSeries/function.go
+++ b/expr/functions/percentileOfSeries/function.go
@@ -36,6 +36,10 @@ func (f *percentileOfSeries) Do(ctx context.Context, e parser.Expr, from, until 
 		return nil, err
 	}
 
+	if len(args) == 0 {
+		return []*types.MetricData{}, nil
+	}
+
 	percent, err := e.GetFloatArg(1)
 	if err != nil {
 		return nil, err

--- a/expr/functions/percentileOfSeries/function_test.go
+++ b/expr/functions/percentileOfSeries/function_test.go
@@ -27,6 +27,13 @@ func TestPercentileOfSeriesSeries(t *testing.T) {
 
 	tests := []th.EvalTestItem{
 		{
+			`percentileOfSeries(metric1.empty,4)`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.empty", 0, 1}: {},
+			},
+			[]*types.MetricData{},
+		},
+		{
 			`percentileOfSeries(metric1,4)`,
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 2, 2, 2, 4, 6, 4, 6, 8, math.NaN()}, 1, now32)},

--- a/expr/functions/rangeOfSeries/function.go
+++ b/expr/functions/rangeOfSeries/function.go
@@ -36,6 +36,10 @@ func (f *rangeOfSeries) Do(ctx context.Context, e parser.Expr, from, until int64
 		return nil, err
 	}
 
+	if len(series) == 0 {
+		return []*types.MetricData{}, nil
+	}
+
 	r := *series[0]
 	r.Name = fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
 	r.Values = make([]float64, len(series[0].Values))

--- a/expr/functions/rangeOfSeries/function_test.go
+++ b/expr/functions/rangeOfSeries/function_test.go
@@ -29,6 +29,13 @@ func TestFunction(t *testing.T) {
 		{
 			"rangeOfSeries(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {},
+			},
+			[]*types.MetricData{},
+		},
+		{
+			"rangeOfSeries(metric*)",
+			map[parser.MetricRequest][]*types.MetricData{
 				{"metric*", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), 3, 4, 12, -10}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), math.NaN(), 15, 0, 6, 10}, 1, now32),

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -39,6 +39,10 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 		return nil, err
 	}
 
+	if len(args) == 0 {
+		return []*types.MetricData{}, nil
+	}
+
 	bucketSizeInt32, err := e.GetIntervalArg(1, 1)
 	if err != nil {
 		return nil, err

--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -20,6 +20,26 @@ func init() {
 	}
 }
 
+func TestSummarizeEmptyData(t *testing.T) {
+	tests := []th.EvalTestItem{
+		{
+			"smartSummarize(metric1,'1hour','sum','1y')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"foo.bar", 0, 1}: {},
+			},
+			[]*types.MetricData{},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}
+
 func TestEvalSummarize(t *testing.T) {
 	tests := []th.SummarizeEvalTestItem{
 		{

--- a/expr/functions/weightedAverage/function.go
+++ b/expr/functions/weightedAverage/function.go
@@ -45,6 +45,11 @@ func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int
 		return nil, err
 	}
 
+	// TODO: should fail if len(avgs) != len(weights)
+	if len(avgs)+len(weights) == 0 {
+		return []*types.MetricData{}, nil
+	}
+
 	alignedMetrics := helper.AlignSeries(append(avgs, weights...))
 	avgs = alignedMetrics[0:len(avgs)]
 	weights = alignedMetrics[len(avgs):]

--- a/expr/functions/weightedAverage/function_test.go
+++ b/expr/functions/weightedAverage/function_test.go
@@ -31,6 +31,13 @@ func TestAbsolute(t *testing.T) {
 		{
 			"weightedAverage(metric*, metric*, 0)",
 			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {},
+			},
+			[]*types.MetricData{},
+		},
+		{
+			"weightedAverage(metric*, metric*, 0)",
+			map[parser.MetricRequest][]*types.MetricData{
 				{"metric*", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
 					types.MakeMetricData("metric2", []float64{None, 2, None, 4, None, 6, None, 8, None, 10, None, 12, None, 14, None, 16, None, 18, None, 20}, 1, now32),

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -145,6 +145,12 @@ type AggregateFunc func([]float64) float64
 
 // AggregateSeries aggregates series
 func AggregateSeries(e parser.Expr, args []*types.MetricData, function AggregateFunc, xFilesFactor float64) ([]*types.MetricData, error) {
+	if len(args) == 0 {
+		// GraphiteWeb does this, no matter the function
+		// https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L228
+		return []*types.MetricData{}, nil
+	}
+
 	var applyXFilesFactor = true
 	args = AlignSeries(args)
 
@@ -269,6 +275,9 @@ func CopyTags(series *types.MetricData) map[string]string {
 }
 
 func GetCommonTags(series []*types.MetricData) map[string]string {
+	if len(series) == 0 {
+		return make(map[string]string)
+	}
 	commonTags := CopyTags(series[0])
 	for _, serie := range series {
 		for k, v := range serie.Tags {


### PR DESCRIPTION
Many functions were panicking when their input series list was empty. I added tests for the ones I found, then fixed them.

Since I found so many functions with this problem, I considered that maybe we shouldn't be passing empty slices as input and that we may be misinterpreting CarbonAPI's interface. But then I saw some functions do handle that case explicitly: [example](https://github.com/grafana/carbonapi/blob/npazosmendez/fix-out-of-range-panics/expr/functions/moving/function.go#L124). I also found old fixes for functions that had the same problem: [example](https://github.com/go-graphite/carbonapi/pull/641). So this led me to believe these are actual bugs and not that we are misusing the interface. 