### PR TITLE
Fix nil map assignment and input data mutation

### DIFF
--- a/expr/functions/hitcount/function.go
+++ b/expr/functions/hitcount/function.go
@@ -78,7 +78,7 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 				StopTime:          stop,
 				ConsolidationFunc: "max",
 			},
-			Tags: arg.Tags,
+			Tags: helper.CopyTags(arg),
 		}
 		r.Tags["hitcount"] = fmt.Sprintf("%d", bucketSizeInt32)
 

--- a/expr/functions/holtWintersAberration/function.go
+++ b/expr/functions/holtWintersAberration/function.go
@@ -86,7 +86,7 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 				ConsolidationFunc: arg.ConsolidationFunc,
 				XFilesFactor:      arg.XFilesFactor,
 			},
-			Tags: arg.Tags,
+			Tags: helper.CopyTags(arg),
 		}
 		r.Tags["holtWintersAberration"] = "1"
 		results = append(results, &r)

--- a/expr/functions/holtWintersConfidenceBands/function.go
+++ b/expr/functions/holtWintersConfidenceBands/function.go
@@ -63,7 +63,7 @@ func (f *holtWintersConfidenceBands) Do(ctx context.Context, e parser.Expr, from
 				XFilesFactor:      arg.XFilesFactor,
 				PathExpression:    fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
 			},
-			Tags: arg.Tags,
+			Tags: helper.CopyTags(arg),
 		}
 		lowerSeries.Tags["holtWintersConfidenceLower"] = "1"
 
@@ -78,7 +78,7 @@ func (f *holtWintersConfidenceBands) Do(ctx context.Context, e parser.Expr, from
 				XFilesFactor:      arg.XFilesFactor,
 				PathExpression:    fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
 			},
-			Tags: arg.Tags,
+			Tags: helper.CopyTags(arg),
 		}
 		upperSeries.Tags["holtWintersConfidenceUpper"] = "1"
 

--- a/expr/functions/holtWintersForecast/function.go
+++ b/expr/functions/holtWintersForecast/function.go
@@ -66,7 +66,7 @@ func (f *holtWintersForecast) Do(ctx context.Context, e parser.Expr, from, until
 				XFilesFactor:      arg.XFilesFactor,
 				ConsolidationFunc: arg.ConsolidationFunc,
 			},
-			Tags: arg.Tags,
+			Tags: helper.CopyTags(arg),
 		}
 		r.Tags["holtWintersConfidenceBands"] = "1"
 


### PR DESCRIPTION
We should copy the tags of the input series if we are mutating them, because:
1. We don't want to mutate the input data
2. The Tags may be nil and can cause panics (it was)