### PR TITLE
Fix groupByNodes panic and adds Tags support to it

### DIFF
--- a/expr/functions/aliasByNode/function.go
+++ b/expr/functions/aliasByNode/function.go
@@ -32,7 +32,7 @@ func (f *aliasByNode) Do(ctx context.Context, e parser.Expr, from, until int64, 
 		return nil, err
 	}
 
-	nodesOrTags, err := e.GetNodeOrTagArgs(1)
+	nodesOrTags, err := e.GetNodeOrTagArgs(1, false)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/groupByNode/function_test.go
+++ b/expr/functions/groupByNode/function_test.go
@@ -50,6 +50,18 @@ func TestGroupByNode(t *testing.T) {
 			},
 		},
 		{
+			Name:   "groupByNode_with_tag",
+			Target: `groupByNode(metric1.foo.*.*,"name","sum")`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				mr: {
+					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
+				},
+			},
+			Results: map[string][]*types.MetricData{
+				"metric1.foo.bar1.baz": {types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+		},
+		{
 			Target: "groupByNode(metric1.foo.*.*,3,\"sum\")",
 			M: map[parser.MetricRequest][]*types.MetricData{
 				mr: {
@@ -127,6 +139,32 @@ func TestGroupByNode(t *testing.T) {
 			Results: map[string][]*types.MetricData{
 				"metric1.foo.baz": {types.MakeMetricData("metric1.foo.baz", []float64{12, 14, 16, 18, 20}, 1, now32)},
 				"metric1.foo.qux": {types.MakeMetricData("metric1.foo.qux", []float64{13, 15, 17, 19, 21}, 1, now32)},
+			},
+		},
+		{
+			Name:   "groupByNodes_out_of_range_node_is_ignored",
+			Target: "groupByNodes(metric1.foo.*.*,\"sum\",0,5,2)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				mr: {
+					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
+				},
+			},
+			Results: map[string][]*types.MetricData{
+				"metric1.bar1": {types.MakeMetricData("metric1.bar1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+		},
+		{
+			Name:   "groupByNodes_tags_and_nodes_combined",
+			Target: `groupByNodes(metric1.foo.*.*,"sum","name",1)`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				mr: {
+					types.MakeMetricData("metric1.foo.bar1.baz", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric1.foo.bar1.bla", []float64{1, 2, 3, 4, 5}, 1, now32),
+				},
+			},
+			Results: map[string][]*types.MetricData{
+				"metric1.foo.bar1.baz.foo": {types.MakeMetricData("metric1.foo.bar1.baz.foo", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				"metric1.foo.bar1.bla.foo": {types.MakeMetricData("metric1.foo.bar1.bla.foo", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
 		},
 	}

--- a/expr/functions/weightedAverage/function.go
+++ b/expr/functions/weightedAverage/function.go
@@ -50,7 +50,7 @@ func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int
 	weights = alignedMetrics[len(avgs):]
 	xFilesFactor := float64(alignedMetrics[0].XFilesFactor)
 
-	nodes, err := e.GetNodeOrTagArgs(2)
+	nodes, err := e.GetNodeOrTagArgs(2, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -146,8 +146,8 @@ type Expr interface {
 	// GetBoolNamedOrPosArgDefault returns specific positioned bool-typed argument or replace it with default if none found.
 	GetBoolNamedOrPosArgDefault(k string, n int, b bool) (bool, error)
 
-	// GetNodeOrTagArgs returns n-th argument as slice of NodeOrTag structures.
-	GetNodeOrTagArgs(n int) ([]NodeOrTag, error)
+	// GetNodeOrTagArgs returns the last arguments starting from the n-th as a slice of NodeOrTag structures. If `single` is `true`, only the n-th argument is taken.
+	GetNodeOrTagArgs(n int, single bool) ([]NodeOrTag, error)
 
 	IsInterfaceNil() bool
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -396,7 +396,7 @@ func (e *expr) GetBoolArgDefault(n int, b bool) (bool, error) {
 	return e.args[n].doGetBoolArg()
 }
 
-func (e *expr) GetNodeOrTagArgs(n int) ([]NodeOrTag, error) {
+func (e *expr) GetNodeOrTagArgs(n int, single bool) ([]NodeOrTag, error) {
 	if len(e.args) <= n {
 		return nil, ErrMissingArgument
 	}
@@ -404,7 +404,11 @@ func (e *expr) GetNodeOrTagArgs(n int) ([]NodeOrTag, error) {
 	var nodeTags []NodeOrTag
 
 	var err error
-	for i := n; i < len(e.args); i++ {
+	until := len(e.args)
+	if single {
+		until = n + 1
+	}
+	for i := n; i < until; i++ {
 		var nodeTag NodeOrTag
 		nodeTag.Value, err = e.GetIntArg(i)
 		if err != nil {


### PR DESCRIPTION
Grouping on a node that's out of range was causing panics. For example `groupByNode(foo.bar.*, 99999,'sum')`. If the data is the metric `foo.bar.baz.bla`, that's only 4 nodes. We saw this panics in our logs and I debugged it.

By making groupByNodes use the `helper.AggKey` helper, not only do we fix this panic but also add the required support for "tags as nodes". See the docs: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.groupByNodes

> Each node may be an integer referencing a node in the series name or a string identifying a tag.