### PR TITLE
Implement verticalLine function

### DIFF
--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -112,6 +112,7 @@ import (
 	"github.com/grafana/carbonapi/expr/functions/transformNull"
 	"github.com/grafana/carbonapi/expr/functions/tukey"
 	"github.com/grafana/carbonapi/expr/functions/unique"
+	"github.com/grafana/carbonapi/expr/functions/verticalLine"
 	"github.com/grafana/carbonapi/expr/functions/weightedAverage"
 	"github.com/grafana/carbonapi/expr/interfaces"
 	"github.com/grafana/carbonapi/expr/metadata"
@@ -234,6 +235,7 @@ func New(configs map[string]string) {
 		{name: "transformNull", filename: "transformNull", order: transformNull.GetOrder(), f: transformNull.New},
 		{name: "tukey", filename: "tukey", order: tukey.GetOrder(), f: tukey.New},
 		{name: "unique", filename: "unique", order: unique.GetOrder(), f: unique.New},
+		{name: "verticalLine", filename: "verticalLine", order: verticalLine.GetOrder(), f: verticalLine.New},
 		{name: "weightedAverage", filename: "weightedAverage", order: weightedAverage.GetOrder(), f: weightedAverage.New},
 	}
 

--- a/expr/functions/verticalLine/function.go
+++ b/expr/functions/verticalLine/function.go
@@ -40,7 +40,7 @@ func (f *verticalLine) Do(_ context.Context, _ parser.Expr, _, _ int64, _ map[pa
 func (f *verticalLine) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
 		"verticalLine": {
-			Description: "Draws a vertical line at the designated timestamp with optional\n  'label' and 'color'. Supported timestamp formats include both\n  relative (e.g. -3h) and absolute (e.g. 16:00_20110501) strings,\n  such as those used with ``from`` and ``until`` parameters. When\n  set, the 'label' will appear in the graph legend.",
+			Description: "Draws a vertical line at the designated timestamp with optional\n  'label' and 'color'. This function is unsupported in this build (built w/o Cairo).",
 			Function:    "verticalLine(ts, label=None, color=None)",
 			Group:       "Graph",
 			Module:      "graphite.render.functions",

--- a/expr/functions/verticalLine/function.go
+++ b/expr/functions/verticalLine/function.go
@@ -1,0 +1,109 @@
+//go:build cairo
+// +build cairo
+
+package verticalLine
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/tags"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+)
+
+var TsOutOfRangeError = fmt.Errorf("timestamp out of range")
+
+type verticalLine struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(_ string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+
+	f := &verticalLine{}
+	functions := []string{"verticalLine"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+
+	return res
+}
+
+func (f *verticalLine) Do(_ context.Context, e parser.Expr, from, until int64, _ map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	start, err := e.GetIntervalArg(0, -1)
+	if err != nil {
+		return nil, err
+	}
+
+	ts := until + int64(start)
+
+	if ts < from {
+		return nil, fmt.Errorf("ts %s is before start %s: %w", time.Unix(ts, 0), time.Unix(from, 0), TsOutOfRangeError)
+	} else if ts > until {
+		return nil, fmt.Errorf("ts %s is after end %s: %w", time.Unix(ts, 0), time.Unix(until, 0), TsOutOfRangeError)
+	}
+
+	label, err := e.GetStringArgDefault(1, "")
+	if err != nil {
+		return nil, err
+	}
+
+	color, err := e.GetStringArgDefault(2, "")
+	if err != nil {
+		return nil, err
+	}
+
+	md := &types.MetricData{
+		FetchResponse: pb.FetchResponse{
+			Name:      label,
+			Values:    []float64{1.0, 1.0},
+			StartTime: ts,
+			StepTime:  1,
+			StopTime:  ts,
+		},
+		Tags: tags.ExtractTags(label),
+		GraphOptions: types.GraphOptions{
+			DrawAsInfinite: true,
+			Color:          color,
+		},
+	}
+
+	return []*types.MetricData{md}, nil
+}
+
+func (f *verticalLine) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"verticalLine": {
+			Description: "Draws a vertical line at the designated timestamp with optional\n  'label' and 'color'. Supported timestamp formats include both\n  relative (e.g. -3h) and absolute (e.g. 16:00_20110501) strings,\n  such as those used with ``from`` and ``until`` parameters. When\n  set, the 'label' will appear in the graph legend.",
+			Function:    "verticalLine(ts, label=None, color=None)",
+			Group:       "Graph",
+			Module:      "graphite.render.functions",
+			Name:        "verticalLine",
+			Params: []types.FunctionParam{
+				{
+					Name:     "ts",
+					Required: true,
+					Type:     types.Date,
+				},
+				{
+					Name:     "label",
+					Required: false,
+					Type:     types.String,
+				},
+				{
+					Name:     "color",
+					Required: false,
+					Type:     types.String,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/verticalLine/function_cairo.go
+++ b/expr/functions/verticalLine/function_cairo.go
@@ -1,17 +1,21 @@
-//go:build !cairo
-// +build !cairo
+//go:build cairo
+// +build cairo
 
 package verticalLine
 
 import (
 	"context"
 	"fmt"
+	"time"
+
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 	"github.com/grafana/carbonapi/expr/interfaces"
+	"github.com/grafana/carbonapi/expr/tags"
 	"github.com/grafana/carbonapi/expr/types"
 	"github.com/grafana/carbonapi/pkg/parser"
 )
 
-var UnsupportedError = fmt.Errorf("must build w/ cairo support")
+var TsOutOfRangeError = fmt.Errorf("timestamp out of range")
 
 type verticalLine struct {
 	interfaces.FunctionBase
@@ -33,8 +37,46 @@ func New(_ string) []interfaces.FunctionMetadata {
 	return res
 }
 
-func (f *verticalLine) Do(_ context.Context, _ parser.Expr, _, _ int64, _ map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	return nil, UnsupportedError
+func (f *verticalLine) Do(_ context.Context, e parser.Expr, from, until int64, _ map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	start, err := e.GetIntervalArg(0, -1)
+	if err != nil {
+		return nil, err
+	}
+
+	ts := until + int64(start)
+
+	if ts < from {
+		return nil, fmt.Errorf("ts %s is before start %s: %w", time.Unix(ts, 0), time.Unix(from, 0), TsOutOfRangeError)
+	} else if ts > until {
+		return nil, fmt.Errorf("ts %s is after end %s: %w", time.Unix(ts, 0), time.Unix(until, 0), TsOutOfRangeError)
+	}
+
+	label, err := e.GetStringArgDefault(1, "")
+	if err != nil {
+		return nil, err
+	}
+
+	color, err := e.GetStringArgDefault(2, "")
+	if err != nil {
+		return nil, err
+	}
+
+	md := &types.MetricData{
+		FetchResponse: pb.FetchResponse{
+			Name:      label,
+			Values:    []float64{1.0, 1.0},
+			StartTime: ts,
+			StepTime:  1,
+			StopTime:  ts,
+		},
+		Tags: tags.ExtractTags(label),
+		GraphOptions: types.GraphOptions{
+			DrawAsInfinite: true,
+			Color:          color,
+		},
+	}
+
+	return []*types.MetricData{md}, nil
 }
 
 func (f *verticalLine) Description() map[string]types.FunctionDescription {

--- a/expr/functions/verticalLine/function_test.go
+++ b/expr/functions/verticalLine/function_test.go
@@ -1,0 +1,121 @@
+//go:build cairo
+// +build cairo
+
+package verticalLine
+
+import (
+	"testing"
+	"time"
+
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/metadata"
+	"github.com/grafana/carbonapi/expr/tags"
+	"github.com/grafana/carbonapi/expr/types"
+	"github.com/grafana/carbonapi/pkg/parser"
+	th "github.com/grafana/carbonapi/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestFunction(t *testing.T) {
+	now := time.Now()
+	nowUnix := now.Unix()
+
+	duration, err := time.ParseDuration("-30m")
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	from := now.Add(duration).Unix()
+
+	wantedDuration, err := time.ParseDuration("-5m")
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	wantedTs := now.Add(wantedDuration).Unix()
+
+	tests := []th.EvalTestItemWithRange{
+		{
+			"verticalLine(\"-5m\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"foo", from, nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
+			},
+			[]*types.MetricData{makeMetricData("", []float64{1.0, 1.0}, 1, wantedTs, wantedTs)},
+			from,
+			nowUnix,
+		},
+		{
+			"verticalLine(\"-5m\", \"label\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"foo", from, nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
+			},
+			[]*types.MetricData{makeMetricData("label", []float64{1.0, 1.0}, 1, wantedTs, wantedTs)},
+			from,
+			nowUnix,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Target, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &test)
+		})
+	}
+}
+
+func TestFunctionErrors(t *testing.T) {
+	now := time.Now()
+	nowUnix := now.Unix()
+
+	duration, err := time.ParseDuration("-30m")
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	from := now.Add(duration).Unix()
+
+	tests := []th.EvalTestItemWithError{
+		{
+			"verticalLine(\"-50m\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"foo", from, nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
+			},
+			[]*types.MetricData{},
+			TsOutOfRangeError,
+		},
+		{
+			"verticalLine(\"+5m\")",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"foo", from, nowUnix}: {types.MakeMetricData("foo", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, 1, nowUnix)},
+			},
+			[]*types.MetricData{},
+			TsOutOfRangeError,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Target, func(t *testing.T) {
+			th.TestEvalExprWithError(t, &test)
+		})
+	}
+}
+
+func makeMetricData(name string, values []float64, step, start, stop int64) *types.MetricData {
+	return &types.MetricData{
+		FetchResponse: pb.FetchResponse{
+			Name:      name,
+			Values:    values,
+			StartTime: start,
+			StepTime:  step,
+			StopTime:  stop,
+		},
+		Tags: tags.ExtractTags(name),
+	}
+}


### PR DESCRIPTION
Function doc: https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.verticalLine
Python implementation: https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L4700-L4743

This PR includes a version of the function that will be used when the executable is built w/o PNG/SVG support; it will simply throw an error saying that the function is unsupported.