### PR TITLE
Add Github Actions workflow for syncing with upstream

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -3,7 +3,7 @@ name: Sync fork with upstream
 on:
   schedule:
     - cron: "12 7 * * 1"
-    # scheduled at 07:12 every Monday and Thursday
+    # scheduled at 07:12 every Monday
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -21,7 +21,7 @@ jobs:
       # Step 2: run this sync action - specify the upstream repo, upstream branch to sync with, and target sync branch
       - name: Pull upstream changes
         id: sync
-        uses: bdougie/Fork-Sync-With-Upstream-action@v3.2
+        uses: bdougie/Fork-Sync-With-Upstream-action@latest
         with:
           target_sync_branch: main
           target_repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -21,7 +21,7 @@ jobs:
       # Step 2: run this sync action - specify the upstream repo, upstream branch to sync with, and target sync branch
       - name: Pull upstream changes
         id: sync
-        uses: bdougie/Fork-Sync-With-Upstream-action@latest
+        uses: aormsby/Fork-Sync-With-Upstream-action@latest
         with:
           target_sync_branch: main
           target_repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -23,10 +23,10 @@ jobs:
         id: sync
         uses: bdougie/Fork-Sync-With-Upstream-action@v3.2
         with:
-          upstream_sync_branch: main
+          target_sync_branch: main
           target_repo_token: ${{ secrets.GITHUB_TOKEN }}
-          upstream_repository: go-graphite/carbonapi
-          upstream_branch: main
+          upstream_sync_repo: go-graphite/carbonapi
+          upstream_sync_branch: main
 
           # Set test_mode true to run tests instead of the true action!!
           test_mode: true

--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -1,0 +1,44 @@
+name: Sync fork with upstream
+
+on:
+  schedule:
+    - cron: "12 7 * * 1"
+    # scheduled at 07:12 every Monday and Thursday
+  workflow_dispatch:
+
+jobs:
+  sync_with_upstream:
+    runs-on: ubuntu-latest
+    name: Sync HEAD with upstream latest
+
+    steps:
+      # Step 1: run a standard checkout action, provided by github
+      - name: Checkout HEAD
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      # Step 2: run this sync action - specify the upstream repo, upstream branch to sync with, and target sync branch
+      - name: Pull upstream changes
+        id: sync
+        uses: bdougie/Fork-Sync-With-Upstream-action@v3.2
+        with:
+          upstream_sync_branch: main
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          upstream_repository: go-graphite/carbonapi
+          upstream_branch: main
+
+          # Set test_mode true to run tests instead of the true action!!
+          test_mode: true
+
+      # Step 3: Display a sample message based on the sync output var 'has_new_commits'
+      - name: New commits found
+        if: steps.sync.outputs.has_new_commits == 'true'
+        run: echo "New commits were found to sync."
+
+      - name: No new commits
+        if: steps.sync.outputs.has_new_commits == 'false'
+        run: echo "There were no new commits."
+
+      - name: Show value of 'has_new_commits'
+        run: echo ${{ steps.sync.outputs.has_new_commits }}


### PR DESCRIPTION
This PR adds a GIthub Actions workflow for syncing this fork to the upstream repository, once a week on Monday.