### PR TITLE
Fix error when no series exists in nested functions

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -169,7 +169,6 @@ func EvalExpr(ctx context.Context, e parser.Expr, from, until int64, values map[
 				parser.ErrBadType,
 				parser.ErrMissingArgument,
 				parser.ErrMissingTimeseries,
-				parser.ErrSeriesDoesNotExist,
 				parser.ErrUnknownTimeUnits,
 			) {
 				err = merry.WithHTTPCode(err, 400)

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -42,12 +42,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 
 	numerators, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
-		if !math.IsNaN(defaultValue) {
-			useConstant = true
-			useDenom = true
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	if len(numerators) == 0 {
 		if !math.IsNaN(defaultValue) {
@@ -61,11 +56,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 
 	denominators, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if err != nil {
-		if !math.IsNaN(defaultValue) && !useConstant {
-			useConstant = true
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	if len(denominators) == 0 {
 		if !math.IsNaN(defaultValue) && !useConstant {

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -44,7 +44,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 
 	numerators, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
-		if merry.Is(err, parser.ErrSeriesDoesNotExist) && !math.IsNaN(defaultValue) {
+		if len(numerators) == 0 && !math.IsNaN(defaultValue) {
 			useConstant = true
 			useDenom = true
 		} else {
@@ -63,7 +63,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 
 	denominators, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if err != nil {
-		if merry.Is(err, parser.ErrSeriesDoesNotExist) && !math.IsNaN(defaultValue) && !useConstant {
+		if len(denominators) == 0 && !math.IsNaN(defaultValue) && !useConstant {
 			useConstant = true
 		} else {
 			return nil, err

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -42,7 +42,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 
 	numerators, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
 	if err != nil {
-		if len(numerators) == 0 && !math.IsNaN(defaultValue) {
+		if !math.IsNaN(defaultValue) {
 			useConstant = true
 			useDenom = true
 		} else {
@@ -61,7 +61,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 
 	denominators, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values)
 	if err != nil {
-		if len(denominators) == 0 && !math.IsNaN(defaultValue) && !useConstant {
+		if !math.IsNaN(defaultValue) && !useConstant {
 			useConstant = true
 		} else {
 			return nil, err

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/ansel1/merry"
-
 	"github.com/grafana/carbonapi/expr/helper"
 	"github.com/grafana/carbonapi/expr/interfaces"
 	"github.com/grafana/carbonapi/expr/types"

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -69,7 +69,7 @@ func GetSeriesArgs(ctx context.Context, e []parser.Expr, from, until int64, valu
 	}
 
 	if len(args) == 0 {
-		return nil, parser.ErrSeriesDoesNotExist
+		return nil, nil
 	}
 
 	return args, nil

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -62,7 +62,7 @@ func GetSeriesArgs(ctx context.Context, e []parser.Expr, from, until int64, valu
 
 	for _, arg := range e {
 		a, err := GetSeriesArg(ctx, arg, from, until, values)
-		if err != nil && !merry.Is(err, parser.ErrSeriesDoesNotExist) {
+		if err != nil {
 			return nil, err
 		}
 		args = append(args, a...)

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -9,7 +9,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/ansel1/merry"
 	"github.com/grafana/carbonapi/expr/interfaces"
 	"github.com/grafana/carbonapi/expr/types"
 	"github.com/grafana/carbonapi/pkg/parser"

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -44,8 +44,6 @@ var (
 	ErrMissingArgument = errors.New("missing argument")
 	// ErrMissingTimeseries is an eval error returned when a time series argument is missing.
 	ErrMissingTimeseries = errors.New("missing time series argument")
-	// ErrSeriesDoesNotExist is an eval error returned when a requested time series argument does not exist.
-	ErrSeriesDoesNotExist = errors.New("no timeseries with that name")
 	// ErrUnknownTimeUnits is an eval error returned when a time unit is unknown to system
 	ErrUnknownTimeUnits = errors.New("unknown time units")
 )

--- a/zipper/helper/requests.go
+++ b/zipper/helper/requests.go
@@ -45,7 +45,7 @@ func MergeHttpErrors(errors []merry.Error) (int, []string) {
 		}
 
 		code := merry.HTTPCode(err)
-		if code == http.StatusNotFound || merry.Is(c, parser.ErrSeriesDoesNotExist) {
+		if code == http.StatusNotFound {
 			continue
 		}
 		if msg := merry.Message(c); len(msg) > 0 {

--- a/zipper/helper/requests.go
+++ b/zipper/helper/requests.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ansel1/merry"
 	"github.com/grafana/carbonapi/limiter"
-	"github.com/grafana/carbonapi/pkg/parser"
 	util "github.com/grafana/carbonapi/util/ctx"
 	"github.com/grafana/carbonapi/zipper/types"
 	"go.uber.org/zap"


### PR DESCRIPTION
This PR fixes an error that is occuring when sumSeries/averageSeries/etc and group functions are called from other functions. 
This error is stemming from sumSeries/averageSeries/etc and group() functions using helper.GetSeriesArgsAndRemoveNonExisting, which was returning an err if the passed in series name didn't match any metrics.

