### PR TITLE
Fix movingWindow's tag names so that target tag is set to string windowSize

### DIFF
--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -220,7 +220,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			}
 			w.Push(v)
 		}
-		r.Tags[e.Target()] = fmt.Sprintf("%d", windowSize)
+		r.Tags[e.Target()] = argstr
 		result = append(result, r)
 	}
 	return result, nil


### PR DESCRIPTION
This PR fixes the setting of the target tag in the movingWindow/movingAverage/movingSum/etc functions so that the value is set to the string version of windowSize as it is passed in, not after it has been converted into an int. 