### PR TITLE
Pin version of ubuntu used for GH actions tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
 
   tests:
     name: Test code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         go:


### PR DESCRIPTION
Looks like we were originally using `ubuntu-latest` which I think was pointing at 18.04 up until recently. Some of the e2e tests have hashes that are OS-dependent for whatever reason, so we'll need to stick to 18.04 for those to pass.