### PR TITLE
Update divideSeries handling of missing denominators

### DIFF
--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -45,6 +45,8 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 
 	var numerators []*types.MetricData
 	var denominator *types.MetricData
+	var results []*types.MetricData
+
 	if e.ArgsLen() == 2 {
 		useMetricNames = true
 		numerators = firstArg
@@ -52,7 +54,20 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		if err != nil {
 			return nil, err
 		}
-		if len(denominators) != 1 {
+
+		if len(denominators) == 0 {
+			for _, numerator := range numerators {
+				r := numerator.CopyLink()
+				r.Name = fmt.Sprintf("divideSeries(%s,MISSING)", numerator.Name)
+				for i, _ := range numerator.Values {
+					r.Values[i] = math.NaN()
+				}
+				results = append(results, r)
+			}
+			return results, nil
+		}
+
+		if len(denominators) > 1 {
 			return nil, types.ErrWildcardNotAllowed
 		}
 
@@ -74,7 +89,6 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		}
 	}
 
-	results := make([]*types.MetricData, 0, len(numerators))
 	for _, numerator := range numerators {
 		r := numerator.CopyLink()
 		if useMetricNames {

--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -58,6 +58,7 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		if len(denominators) == 0 {
 			for _, numerator := range numerators {
 				r := numerator.CopyLink()
+				r.Values = make([]float64, len(numerator.Values))
 				r.Name = fmt.Sprintf("divideSeries(%s,MISSING)", numerator.Name)
 				for i, _ := range numerator.Values {
 					r.Values[i] = math.NaN()

--- a/expr/functions/divideSeries/function_test.go
+++ b/expr/functions/divideSeries/function_test.go
@@ -80,6 +80,14 @@ func TestDivideSeries(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("divideSeries(metric[12])",
 				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2}, 1, now32).SetNameTag("metric1")},
 		},
+		{
+			"divideSeries(testMetric,metric)", // verify that a non-existant denominator will not error out and instead will return a list of math.NaN() values
+			map[parser.MetricRequest][]*types.MetricData{
+				{"testMetric", 0, 1}: {types.MakeMetricData("testMetric", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("divideSeries(testMetric,MISSING)",
+				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR updates the divideSeries function's handling of the case in which the denominator(s) are missing. Previously, CarbonAPI would return an error if the length of denominators was equal to zero. This appears to be inconsistent with how Graphite web handled this scenario, in which a value of None was returned for each value in the returned series (see [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L1120). In this case, instead of None, math.NaN() is returned. This is consistent with how asPercent handles missing values.