### PR TITLE
Fix tag handling in nested functions

### DIFF
--- a/expr/functions/alias/function.go
+++ b/expr/functions/alias/function.go
@@ -49,7 +49,6 @@ func (f *alias) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		if allowFormatStr {
 			name = strings.ReplaceAll(name, "${expr}", arg.Name)
 		}
-
 		r := arg.CopyName(name)
 
 		results[i] = r

--- a/expr/functions/aliasByBase64/function.go
+++ b/expr/functions/aliasByBase64/function.go
@@ -46,7 +46,8 @@ func (f *aliasByBase64) Do(ctx context.Context, e parser.Expr, from, until int64
 		if withoutFieldArg {
 			decoded, err := base64.StdEncoding.DecodeString(a.Name)
 			if err == nil {
-				r = a.CopyName(string(decoded))
+				r = a.CopyLink()
+				r.Name = string(decoded)
 			} else {
 				r = a
 			}

--- a/expr/functions/aliasByNode/function.go
+++ b/expr/functions/aliasByNode/function.go
@@ -40,8 +40,7 @@ func (f *aliasByNode) Do(ctx context.Context, e parser.Expr, from, until int64, 
 	results := make([]*types.MetricData, len(args))
 
 	for i, a := range args {
-		name := helper.AggKey(a, nodesOrTags)
-		r := a.CopyName(name)
+		r := a.CopyName(helper.AggKey(a, nodesOrTags))
 		results[i] = r
 	}
 

--- a/expr/functions/aliasSub/function.go
+++ b/expr/functions/aliasSub/function.go
@@ -61,10 +61,10 @@ func (f *aliasSub) Do(ctx context.Context, e parser.Expr, from, until int64, val
 		name := re.ReplaceAllString(oldName, replace)
 		if oldName == name {
 			r = a.CopyLinkTags()
+			r.Tags["name"] = r.Name
 		} else {
 			r = a.CopyName(name)
 		}
-
 		results[i] = r
 	}
 

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -448,35 +448,13 @@ func (r *MetricData) CopyLinkTags() *MetricData {
 	}
 }
 
-// CopyName returns the copy of MetricData, Values not copied and link from parent. If name set, Name and Name tag changed, Tags wil be reset
+// CopyName returns the copy of MetricData, Values not copied and link from parent. If name set, Name and Name tag changed
 func (r *MetricData) CopyName(name string) *MetricData {
-	if name == "" {
-		return r.CopyLink()
-	}
+	res := r.CopyLink()
+	res.Name = name
+	res.Tags["name"] = name
 
-	tags := tags.ExtractTags(ExtractName(name))
-
-	return &MetricData{
-		FetchResponse: pb.FetchResponse{
-			Name:                    name,
-			PathExpression:          r.PathExpression,
-			ConsolidationFunc:       r.ConsolidationFunc,
-			StartTime:               r.StartTime,
-			StopTime:                r.StopTime,
-			StepTime:                r.StepTime,
-			XFilesFactor:            r.XFilesFactor,
-			HighPrecisionTimestamps: r.HighPrecisionTimestamps,
-			Values:                  r.Values,
-			AppliedFunctions:        r.AppliedFunctions,
-			RequestStartTime:        r.RequestStartTime,
-			RequestStopTime:         r.RequestStopTime,
-		},
-		GraphOptions:      r.GraphOptions,
-		ValuesPerPoint:    r.ValuesPerPoint,
-		aggregatedValues:  r.aggregatedValues,
-		Tags:              tags,
-		AggregateFunction: r.AggregateFunction,
-	}
+	return res
 }
 
 // CopyName returns the copy of MetricData, Values not copied and link from parent. If name set, Name and Name tag changed, Tags wil be reset


### PR DESCRIPTION
This PR fixes an issue in which tags were not being properly set for the results of the  outer function when Graphite web functions are nested. Previously, for certain functions, if there is another function is an argument that returns results, the tags that had been assigned to the resulting series are not included in the final result of the query. This is because some functions do not copy over tags. Some examples of such functions include aliasByNode, alias, and aggregateLine.

Example:

aliasByNode(absolute(testMetric),1))

The results of this query should now return the "name" tag and the "absolute" tag, instead of just the "name" tag.