### PR TITLE
Revert "Add missing tags based on MetricData.Name"

### DIFF
--- a/cmd/carbonapi/http/main_test.go
+++ b/cmd/carbonapi/http/main_test.go
@@ -138,7 +138,7 @@ func TestRenderHandler(t *testing.T) {
 	req, rr := setUpRequest(t, "/render/?target=fallbackSeries(foo.bar,foo.baz)&from=-10minutes&format=json")
 	renderHandler(rr, req)
 
-	expected := `[{"target":"foo.bar","datapoints":[[null,1510913280],[1510913759,1510913340],[1510913818,1510913400]],"tags":{"name":"foo.bar"}}]`
+	expected := `[{"target":"foo.bar","datapoints":[[null,1510913280],[1510913759,1510913340],[1510913818,1510913400]],"tags":{}}]`
 
 	// Check the status code is what we expect.
 	r := assert.Equal(t, rr.Code, http.StatusOK, "HttpStatusCode should be 200 OK.")

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -3,17 +3,16 @@ package expr
 import (
 	"context"
 
-	"github.com/ansel1/merry"
+	utilctx "github.com/grafana/carbonapi/util/ctx"
 
+	"github.com/ansel1/merry"
 	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 	"github.com/grafana/carbonapi/cmd/carbonapi/config"
 	_ "github.com/grafana/carbonapi/expr/functions"
 	"github.com/grafana/carbonapi/expr/helper"
 	"github.com/grafana/carbonapi/expr/metadata"
-	"github.com/grafana/carbonapi/expr/tags"
 	"github.com/grafana/carbonapi/expr/types"
 	"github.com/grafana/carbonapi/pkg/parser"
-	utilctx "github.com/grafana/carbonapi/util/ctx"
 )
 
 type evaluator struct{}
@@ -97,7 +96,7 @@ func (eval evaluator) FetchAndEvalExp(ctx context.Context, exp parser.Expr, from
 	return eval.Eval(ctx, exp, from, until, targetValues)
 }
 
-// Eval evaluates expressions
+// Eval evalualtes expressions
 func (eval evaluator) Eval(ctx context.Context, exp parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (results []*types.MetricData, err error) {
 	rewritten, targets, err := RewriteExpr(ctx, exp, from, until, values)
 	if err != nil {
@@ -132,7 +131,7 @@ func FetchAndEvalExp(ctx context.Context, e parser.Expr, from, until int64, valu
 	return _evaluator.FetchAndEvalExp(ctx, e, from, until, values)
 }
 
-// EvalExpr is the main expression evaluator
+// Eval is the main expression evaluator
 func EvalExpr(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	if e.IsName() {
 		return values[parser.MetricRequest{Metric: e.Target(), From: from, Until: until}], nil
@@ -175,21 +174,6 @@ func EvalExpr(ctx context.Context, e parser.Expr, from, until int64, values map[
 				err = merry.WithHTTPCode(err, 400)
 			}
 		}
-
-		for _, md := range v {
-			if md.Tags == nil {
-				md.Tags = make(map[string]string)
-			}
-
-			if _, ok := md.Tags["name"]; !ok {
-				for k, v := range tags.ExtractTags(md.Name) {
-					if _, ok := md.Tags[k]; !ok {
-						md.Tags[k] = v
-					}
-				}
-			}
-		}
-
 		return v, err
 	}
 


### PR DESCRIPTION
Reverts grafana/carbonapi#66

https://github.com/grafana/transmog/issues/1419

Looks like @carrieedwards has added this functionality further down the pipe already (https://github.com/grafana/transmog/blob/e04613537a8953602db0f7dc034496e6763d9faa/pkg/carbonapiadapter/adapter.go#L100-L103) so this can be reverted.