### PR TITLE
Add backend protocol for Mimir

### DIFF
--- a/cmd/carbonapi/carbonapi.example.mimir.yaml
+++ b/cmd/carbonapi/carbonapi.example.mimir.yaml
@@ -1,0 +1,71 @@
+listen: "localhost:8081"
+concurency: 1000
+cache:
+  type: "mem"
+  size_mb: 0
+  defaultTimeoutSec: 60
+  memcachedServers:
+    - "127.0.0.1:1234"
+    - "127.0.0.2:1235"
+cpus: 0
+tz: ""
+headersToPass:
+  - "X-Dashboard-Id"
+  - "X-Grafana-Org-Id"
+  - "X-Panel-Id"
+functionsConfig:
+  graphiteWeb: cmd/carbonapi/graphiteWeb.example.yaml
+maxBatchSize: 0
+graphite:
+  host: ""
+  interval: "60s"
+  prefix: "carbon.api"
+  pattern: "{prefix}.{fqdn}"
+idleConnections: 10
+upstreams:
+  buckets: 10
+
+  timeouts:
+    find: "2s"
+    render: "10s"
+    connect: "200ms"
+  concurrencyLimitPerServer: 0
+
+  keepAliveInterval: "30s"
+  maxIdleConnsPerHost: 100
+  backendsv2:
+    backends:
+      - groupName: "mimir"
+        protocol: "mimir"
+        lbMethod: "broadcast"
+        maxTries: 3
+        maxBatchSize: 0
+        keepAliveInterval: "10s"
+        concurrencyLimit: 0
+        maxIdleConnsPerHost: 1000
+        backendOptions:
+          step: "60"
+          start: "-5m"
+          max_points_per_query: 5000
+          force_min_step_interval: 1h
+          tenant_id: "10286"
+        timeouts:
+          find: "2s"
+          render: "50s"
+          connect: "200ms"
+        servers:
+          - "http://127.0.0.1:8080/prometheus"
+  graphite09compat: false
+graphTemplates: cmd/carbonapi/graphTemplates.example.yaml
+expireDelaySec: 10
+logger:
+  - logger: ""
+    file: "stderr"
+    level: "debug"
+    encoding: "console"
+    encodingTime: "iso8601"
+    encodingDuration: "seconds"
+  - logger: ""
+    file: "carbonapi.log"
+    level: "info"
+    encoding: "json"

--- a/zipper/protocols/mimir/mimir_group.go
+++ b/zipper/protocols/mimir/mimir_group.go
@@ -1,0 +1,61 @@
+package mimir
+
+import (
+	"context"
+	"github.com/ansel1/merry"
+
+	"github.com/grafana/carbonapi/limiter"
+	"github.com/grafana/carbonapi/zipper/helper"
+	"github.com/grafana/carbonapi/zipper/metadata"
+	"github.com/grafana/carbonapi/zipper/protocols/prometheus"
+	"github.com/grafana/carbonapi/zipper/types"
+
+	"go.uber.org/zap"
+)
+
+func init() {
+	metadata.Metadata.Lock()
+	defer metadata.Metadata.Unlock()
+
+	metadata.Metadata.SupportedProtocols["mimir"] = struct{}{}
+	metadata.Metadata.ProtocolInits["mimir"] = New
+	metadata.Metadata.ProtocolInitsWithLimiter["mimir"] = NewWithLimiter
+}
+
+func New(logger *zap.Logger, config types.BackendV2, tldCacheDisabled bool) (types.BackendServer, merry.Error) {
+	if config.ConcurrencyLimit == nil {
+		return nil, types.ErrConcurrencyLimitNotSet
+	}
+	if len(config.Servers) == 0 {
+		return nil, types.ErrNoServersSpecified
+	}
+	l := limiter.NewServerLimiter([]string{config.GroupName}, *config.ConcurrencyLimit)
+
+	return NewWithLimiter(logger, config, tldCacheDisabled, l)
+}
+
+func NewWithLimiter(logger *zap.Logger, config types.BackendV2, tldCacheDisabled bool, limiter limiter.ServerLimiter) (types.BackendServer, merry.Error) {
+	pg, err := prometheus.NewPrometheusGroupWithLimiter(logger, config, tldCacheDisabled, limiter)
+	if err != nil {
+		logger.Fatal("problem creating prometheus group with limiter", zap.Error(err))
+	}
+
+	rawTenantID, ok := config.BackendOptions["tenant_id"]
+	if !ok {
+		logger.Fatal("missing required option tenant ID")
+	}
+	tenantID, ok := rawTenantID.(string)
+	if !ok {
+		logger.Fatal("failed to cast tenant ID as a string")
+	}
+
+	pg.QueryExecutor = func(httpQuery *helper.HttpQuery, ctx context.Context, logger *zap.Logger, uri string, r types.Request) (*helper.ServerResponse, merry.Error) {
+		headers := map[string]string{
+			"X-Scope-OrgID": tenantID,
+		}
+
+		return httpQuery.DoQueryWithAdditionalHeaders(ctx, logger, uri, r, headers)
+	}
+
+	return pg, nil
+}

--- a/zipper/zipper.go
+++ b/zipper/zipper.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/grafana/carbonapi/zipper/protocols/auto"
 	_ "github.com/grafana/carbonapi/zipper/protocols/graphite"
 	_ "github.com/grafana/carbonapi/zipper/protocols/irondb"
+	_ "github.com/grafana/carbonapi/zipper/protocols/mimir"
 	_ "github.com/grafana/carbonapi/zipper/protocols/prometheus"
 	_ "github.com/grafana/carbonapi/zipper/protocols/v2"
 	_ "github.com/grafana/carbonapi/zipper/protocols/v3"


### PR DESCRIPTION
https://github.com/grafana/query-squad/issues/186

This PR adds Mimir as a backend protocol as well as changing the `ProbeTLDs` method for `PrometheusGroup`.

As far as I can tell, the `ProbeTLDs` method runs a very expensive query against Prometheus (and also Mimir) and then does nothing with the results so I went ahead and just had it return `[]string{}` instead. 