### PR TITLE
Allow inf as value for limit parameter in keepLastValue

### DIFF
--- a/expr/functions/keepLastValue/function.go
+++ b/expr/functions/keepLastValue/function.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/carbonapi/pkg/parser"
 	"math"
 	"strconv"
+	"strings"
 )
 
 type keepLastValue struct {
@@ -39,7 +40,7 @@ func (f *keepLastValue) Do(ctx context.Context, e parser.Expr, from, until int64
 	var keep int
 	var keepStr string
 
-	if e.ArgsLen() == 2 && e.Arg(1).Target() == "inf" {
+	if e.ArgsLen() == 2 && strings.ToLower(e.Arg(1).Target()) == "inf" {
 		keep = -1
 		keepStr = "inf"
 	} else {

--- a/expr/functions/keepLastValue/function.go
+++ b/expr/functions/keepLastValue/function.go
@@ -2,13 +2,12 @@ package keepLastValue
 
 import (
 	"context"
-	"math"
-	"strconv"
-
 	"github.com/grafana/carbonapi/expr/helper"
 	"github.com/grafana/carbonapi/expr/interfaces"
 	"github.com/grafana/carbonapi/expr/types"
 	"github.com/grafana/carbonapi/pkg/parser"
+	"math"
+	"strconv"
 )
 
 type keepLastValue struct {
@@ -31,25 +30,33 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 // keepLastValue(seriesList, limit=inf)
 func (f *keepLastValue) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+
 	arg, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}
 
-	keep, err := e.GetIntNamedOrPosArgDefault("limit", 1, -1)
-	if err != nil {
-		return nil, err
-	}
+	var keep int
 	var keepStr string
-	if keep != -1 {
-		keepStr = strconv.Itoa(keep)
+
+	if e.ArgsLen() == 2 && e.Arg(1).Target() == "inf" {
+		keep = -1
+		keepStr = "inf"
+	} else {
+		keep, err = e.GetIntNamedOrPosArgDefault("limit", 1, -1)
+		if err != nil {
+			return nil, err
+		}
+		if keep != -1 {
+			keepStr = strconv.Itoa(keep)
+		}
 	}
 
 	var results []*types.MetricData
 
 	for _, a := range arg {
 		var name string
-		if keep == -1 {
+		if keepStr == "" {
 			name = "keepLastValue(" + a.Name + ")"
 		} else {
 			name = "keepLastValue(" + a.Name + "," + keepStr + ")"

--- a/expr/functions/keepLastValue/function_test.go
+++ b/expr/functions/keepLastValue/function_test.go
@@ -42,6 +42,14 @@ func TestFunction(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("keepLastValue(metric1)", []float64{math.NaN(), 2, 2, 2, 2, 2, 4, 5}, 1, now32)},
 		},
 		{
+			"keepLastValue(metric1,inf)",
+
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 2, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("keepLastValue(metric1,inf)", []float64{math.NaN(), 2, 2, 2, 2, 2, 4, 5}, 1, now32)},
+		},
+		{
 			"keepLastValue(metric*)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric*", 0, 1}: {


### PR DESCRIPTION
The implementation of keepLastValue was expecting an integer value, while the default value of keepLastValue is inf. If a user passed in inf for the limit parameter, an ErrBadType would be thrown. To prevent this error from being thrown, and to be consistent with Graphite web, inf is now handled as an acceptable value for limit. 

The definition of keepLastValue is: 

```
keepLastValue(seriesList, limit=inf)
Takes one metric or a wildcard seriesList, and optionally a limit to the number of ‘None’ values to skip over. Continues the line with the last received value when gaps (‘None’ values) appear in your data, rather than breaking your line.

Example:

&target=keepLastValue(Server01.connections.handled)
&target=keepLastValue(Server01.connections.handled, 10)
```

[Here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L740) is the Graphite web implementation of keepLastValue.