### PR TITLE
Fix asPercent error when series has more values than totalSeries

### DIFF
--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -85,7 +85,11 @@ func seriesAsPercent(arg, total []*types.MetricData) []*types.MetricData {
 	} else if len(total) == 1 {
 		// asPercent(seriesList, totalSeries)
 		for _, a := range arg {
-			for i := range a.Values {
+			var maxIndex = len(a.Values)
+			if len(a.Values) > len(total[0].Values) {
+				maxIndex = len(total[0].Values)
+			}
+			for i := 0; i < maxIndex; i++ {
 				t := total[0].Values[i]
 				if math.IsNaN(a.Values[i]) || math.IsNaN(t) || t == 0 {
 					a.Values[i] = math.NaN()
@@ -103,7 +107,11 @@ func seriesAsPercent(arg, total []*types.MetricData) []*types.MetricData {
 		if len(arg) <= len(total) {
 			// asPercent(seriesList, totalSeriesList) for series with len(seriesList) <= len(totalSeriesList)
 			for n, a := range arg {
-				for i := range a.Values {
+				var maxIndex = len(a.Values)
+				if len(a.Values) > len(total[n].Values) {
+					maxIndex = len(total[n].Values)
+				}
+				for i := 0; i < maxIndex; i++ {
 					t := total[n].Values[i]
 					if math.IsNaN(a.Values[i]) || math.IsNaN(t) || t == 0 {
 						a.Values[i] = math.NaN()

--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -72,6 +72,7 @@ func calculatePercentage(seriesValue, totalValue float64) float64 {
 }
 
 func getPercentages(series, totalSeries *types.MetricData) {
+	// If there are more series values than totalSeries values, set series value to math.NaN() for those indices
 	if len(series.Values) > len(totalSeries.Values) {
 		for i := 0; i < len(totalSeries.Values); i++ {
 			series.Values[i] = calculatePercentage(series.Values[i], totalSeries.Values[i])
@@ -82,6 +83,13 @@ func getPercentages(series, totalSeries *types.MetricData) {
 	} else {
 		for i := range series.Values {
 			series.Values[i] = calculatePercentage(series.Values[i], totalSeries.Values[i])
+		}
+
+		// If there are more totalSeries values than series values, append math.NaN() to the series values
+		if lengthDiff := len(totalSeries.Values) - len(series.Values); lengthDiff > 0 {
+			for i := 0; i < lengthDiff; i++ {
+				series.Values = append(series.Values, math.NaN())
+			}
 		}
 	}
 }

--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -71,6 +71,13 @@ func calculatePercentage(seriesValue, totalValue float64) float64 {
 	return value
 }
 
+// GetPercentages contains the logic to apply to the series in order to properly
+// calculate percentages. If the length of the values in series and totalSeries are
+// not equal, special handling is required. If the number of values in seriesList is
+// greater than the number of values in totalSeries, math.NaN() needs to be set to the
+// indices in series starting at the length of totalSeries.Values. If the number of values
+// in totalSeries is greater than the number of values in series, then math.NaN() needs
+// to be appended to series until its values have the same length as totalSeries.Values
 func getPercentages(series, totalSeries *types.MetricData) {
 	// If there are more series values than totalSeries values, set series value to math.NaN() for those indices
 	if len(series.Values) > len(totalSeries.Values) {

--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -23,7 +23,7 @@ func init() {
 	}
 }
 
-func TestAsPersent(t *testing.T) {
+func TestAsPercent(t *testing.T) {
 	now32 := int64(time.Now().Unix())
 	NaN := math.NaN()
 
@@ -70,6 +70,23 @@ func TestAsPersent(t *testing.T) {
 				types.MakeMetricData("asPercent(Server1.memory.used,Server1.memory.total)", []float64{25, 500, 125}, 1, now32),
 				types.MakeMetricData("asPercent(Server2.memory.used,Server3.memory.total)", []float64{25, 62.5, 1000}, 1, now32),
 			},
+		},
+		{
+			"asPercent(metricC*,metricD*)", // This test is to verify that passing in metrics with different number of values and different step values for the series and the totalSeries does not throw an error
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metricC*", 0, 1}: {
+					types.MakeMetricData("metricC1", []float64{1, 20, 10, 15, 5}, 1, now32), // Test that error isn't thrown when seriesList has more values than totalSeries
+					types.MakeMetricData("metricC2", []float64{1, 10, 20, 15, 5}, 1, now32),
+				},
+				{"metricD*", 0, 1}: {
+					types.MakeMetricData("metricD1", []float64{4, 4, 8}, 2, now32),
+					types.MakeMetricData("metricD2", []float64{4, 16, 2}, 2, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("asPercent(metricC1,metricD1)",
+				[]float64{25, 500, 125, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+				types.MakeMetricData("asPercent(metricC2,metricD2)",
+					[]float64{25, 62.5, 1000, math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 		},
 
 		// Extend tests
@@ -151,7 +168,7 @@ func TestAsPersent(t *testing.T) {
 	}
 }
 
-func TestAsPersentAligment(t *testing.T) {
+func TestAsPercentAlignment(t *testing.T) {
 	now32 := int64(time.Now().Unix())
 	NaN := math.NaN()
 	testAlignments := []th.EvalTestItem{
@@ -211,7 +228,7 @@ func TestAsPersentAligment(t *testing.T) {
 	}
 }
 
-func TestAsPersentGroup(t *testing.T) {
+func TestAsPercentGroup(t *testing.T) {
 	now32 := int64(time.Now().Unix())
 	NaN := math.NaN()
 


### PR DESCRIPTION
This PR fixes an error that has been found when the length of the series values is greater than the length of the totalSeries values that are being used to calculate the percentage. The error is thrown because the index that is attempting to be accessed in the totalSeries is out of range. 