### PR TITLE
Update spacing in removeBelowSeries assignment of name to match Graphite web

### DIFF
--- a/expr/functions/removeBelowSeries/function.go
+++ b/expr/functions/removeBelowSeries/function.go
@@ -70,7 +70,7 @@ func (f *removeBelowSeries) Do(ctx context.Context, e parser.Expr, from, until i
 		}
 
 		r := a.CopyLink()
-		r.Name = e.Target() + "(" + a.Name + "," + numberStr + ")"
+		r.Name = e.Target() + "(" + a.Name + ", " + numberStr + ")"
 		r.Values = make([]float64, len(a.Values))
 		r.Tags["removeBelowSeries"] = fmt.Sprintf("%f", threshold)
 

--- a/expr/functions/removeBelowSeries/function_test.go
+++ b/expr/functions/removeBelowSeries/function_test.go
@@ -31,7 +31,7 @@ func TestFunction(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("removeBelowValue(metric1,0)",
+			[]*types.MetricData{types.MakeMetricData("removeBelowValue(metric1, 0)",
 				[]float64{1, 2, math.NaN(), 7, 8, 20, 30, math.NaN()}, 1, now32)},
 		},
 		{
@@ -39,7 +39,7 @@ func TestFunction(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("removeAboveValue(metric1,10)",
+			[]*types.MetricData{types.MakeMetricData("removeAboveValue(metric1, 10)",
 				[]float64{1, 2, -1, 7, 8, math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 		},
 		{
@@ -47,7 +47,7 @@ func TestFunction(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("removeBelowPercentile(metric1,50)",
+			[]*types.MetricData{types.MakeMetricData("removeBelowPercentile(metric1, 50)",
 				[]float64{math.NaN(), math.NaN(), math.NaN(), 7, 8, 20, 30, math.NaN()}, 1, now32)},
 		},
 		{
@@ -55,7 +55,7 @@ func TestFunction(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 30, math.NaN()}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("removeAbovePercentile(metric1,50)",
+			[]*types.MetricData{types.MakeMetricData("removeAbovePercentile(metric1, 50)",
 				[]float64{1, 2, -1, 7, math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
 		},
 	}


### PR DESCRIPTION
This PR updates the spacing in removeBelowSeries assignment of name in MetricData to include a space between the series name and number threshold. This is to match Graphite web's assignment of name for the results for removeBelowSeries.