### PR TITLE
Use ExtractMetric for name parsing in aliasByMetric and sumSeriesWithWildcards

### DIFF
--- a/expr/functions/aliasByMetric/function.go
+++ b/expr/functions/aliasByMetric/function.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/grafana/carbonapi/expr/helper"
+	"github.com/grafana/carbonapi/expr/helper/metric"
 	"github.com/grafana/carbonapi/expr/interfaces"
 	"github.com/grafana/carbonapi/expr/types"
 	"github.com/grafana/carbonapi/pkg/parser"
@@ -30,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 func (f *aliasByMetric) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	return helper.ForEachSeriesDo1(ctx, e, from, until, values, func(a *types.MetricData) *types.MetricData {
-		metric := a.Tags["name"]
+		metric := metric.ExtractMetric(a.Name)
 		part := strings.Split(metric, ".")
 		name := part[len(part)-1]
 		ret := a.CopyName(name)

--- a/expr/functions/sumSeriesWithWildcards/function.go
+++ b/expr/functions/sumSeriesWithWildcards/function.go
@@ -2,6 +2,7 @@ package sumSeriesWithWildcards
 
 import (
 	"context"
+	"github.com/grafana/carbonapi/expr/helper/metric"
 	"math"
 	"strings"
 
@@ -46,7 +47,7 @@ func (f *sumSeriesWithWildcards) Do(ctx context.Context, e parser.Expr, from, un
 	groups := make(map[string][]*types.MetricData)
 
 	for _, a := range args {
-		metric := a.Tags["name"]
+		metric := metric.ExtractMetric(a.Name)
 		nodes := strings.Split(metric, ".")
 		s := make([]string, 0, len(nodes))
 		// Yes, this is O(n^2), but len(nodes) < 10 and len(fields) < 3


### PR DESCRIPTION
This PR updates aliasByMetric and sumSeriesWithWildcards to use ExtractMetric to grab the name of the metric instead of using the name tag. Since some functions set the name of the series as the function name + series name, using the name tag to get the metric name could cause metrics with parentheses in them. ExtractMetric parses out parentheses properly, preventing this issue.