### PR TITLE
Add consolidation function aliases to function mapping

### DIFF
--- a/expr/consolidations/consolidations.go
+++ b/expr/consolidations/consolidations.go
@@ -24,13 +24,16 @@ var ConsolidationToFunc = map[string]func([]float64) float64{
 	"minimum":  AggMin,
 	"multiply": summarizeToAggregate("multiply"),
 	"range":    summarizeToAggregate("range"),
+	"rangeOf":  summarizeToAggregate("rangeOf"),
 	"sum":      AggSum,
+	"total":    AggSum,
 	"stddev":   summarizeToAggregate("stddev"),
 	"first":    AggFirst,
 	"last":     AggLast,
+	"current":  AggLast,
 }
 
-var AvailableSummarizers = []string{"sum", "total", "avg", "average", "avg_zero", "max", "min", "last", "range", "median", "multiply", "diff", "count", "stddev"}
+var AvailableSummarizers = []string{"sum", "total", "avg", "average", "avg_zero", "max", "min", "last", "current", "range", "rangeOf", "median", "multiply", "diff", "count", "stddev"}
 
 // AvgValue returns average of list of values
 func AvgValue(f64s []float64) float64 {
@@ -167,10 +170,10 @@ func SummarizeValues(f string, values []float64, XFilesFactor float32) float64 {
 				}
 			}
 		}
-	case "last":
+	case "last", "current":
 		rv = values[len(values)-1]
 		total = notNans(values)
-	case "range":
+	case "range", "rangeOf":
 		vMax := math.Inf(-1)
 		vMin := math.Inf(1)
 		isNaN := true

--- a/expr/functions/aggregate/function_test.go
+++ b/expr/functions/aggregate/function_test.go
@@ -101,6 +101,18 @@ func TestAverageSeries(t *testing.T) {
 				[]float64{3, math.NaN(), 4, 5, 6, 6}, 1, now32)},
 		},
 		{
+			`aggregate(metric[123], "current")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 6}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("currentSeries(metric[123])",
+				[]float64{3, math.NaN(), 4, 5, 6, 6}, 1, now32)},
+		},
+		{
 			`aggregate(metric[123], "max")`,
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric[123]", 0, 1}: {
@@ -161,6 +173,18 @@ func TestAverageSeries(t *testing.T) {
 				[]float64{2, math.NaN(), 2, 2, 2, 1}, 1, now32)},
 		},
 		{
+			`aggregate(metric[123], "rangeOf")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("rangeOfSeries(metric[123])",
+				[]float64{2, math.NaN(), 2, 2, 2, 1}, 1, now32)},
+		},
+		{
 			`aggregate(metric[123], "sum")`,
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric[123]", 0, 1}: {
@@ -170,6 +194,18 @@ func TestAverageSeries(t *testing.T) {
 				},
 			},
 			[]*types.MetricData{types.MakeMetricData("sumSeries(metric[123])",
+				[]float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
+		},
+		{
+			`aggregate(metric[123], "total")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[123]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), 2, 3, 4, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 5}, 1, now32),
+					types.MakeMetricData("metric3", []float64{3, math.NaN(), 4, 5, 6, math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("totalSeries(metric[123])",
 				[]float64{6, math.NaN(), 9, 8, 15, 11}, 1, now32)},
 		},
 		{


### PR DESCRIPTION
This PR adds missing aliases for consolidation functions to the mapping that matches a string function name to the appropriate consolidation function. This will prevent errors from being thrown if a user passes in an alias as an argument to a Graphite web function that accepts aggregation functions as a parameter, such as:

`aggregate(metric*Name, 'total')`

These aliases should match [Graphite web's mapping](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/functions/aggfuncs.py#L21)