### PR TITLE
Add handling for '+' char in metric names in queries

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -570,7 +570,7 @@ func IsNameChar(r byte) bool {
 		r == '<' || r == '>' ||
 		r == '&' || r == '#' ||
 		r == '/' || r == '%' ||
-		r == '@'
+		r == '@' || r == '+'
 }
 
 func isDigit(r byte) bool {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -265,6 +265,13 @@ func TestParseExpr(t *testing.T) {
 			},
 		},
 		{
+			`foo.b[0-9]+.qux`,
+			&expr{
+				target: "foo.b[0-9]+.qux",
+				etype:  EtName,
+			},
+		},
+		{
 			`virt.v1.*.text-match:<foo.bar.qux>`,
 			&expr{
 				target: "virt.v1.*.text-match:<foo.bar.qux>",


### PR DESCRIPTION
This PR fixes an error we were seeing in which including a '+' symbol as part of a regular expression in a metric name was resulting in an error being thrown. For example:

alias(testMetric[0-9]+.Metric, 'name')

throws an error of:  `unexpected character.`

The [Graphite docs](https://graphite.readthedocs.io/en/latest/render_api.html#paths-and-wildcards) on wildcard expressions do not explicitly mention the '+' character as unsupported, it does not throw an error and seems to process it. Therefore, this PR aims to make parsing more consistent with Graphite web.