### PR TITLE
Align series by step in *seriesLists functions if steps or value length not equal

### DIFF
--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -2,7 +2,6 @@ package seriesList
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -151,11 +150,16 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 			}
 		}
 		if pairFound {
-			if numerator.StepTime != denominator.StepTime || len(numerator.Values) != len(denominator.Values) {
-				return nil, fmt.Errorf("series %s must have the same length as %s", numerator.Name, denominator.Name)
+			pair := []*types.MetricData{numerator, denominator}
+			step, alignStep := helper.GetCommonStep(pair)
+			if alignStep || len(numerator.Values) != len(denominator.Values) {
+				alignedSeries := helper.ScaleToCommonStep(types.CopyMetricDataSlice(pair), step)
+				numerator = alignedSeries[0]
+				denominator = alignedSeries[1]
 			}
 		}
-		r := *numerator
+
+		r := numerator.CopyLink()
 		var denomName string
 		if pairFound {
 			denomName = denominator.Name
@@ -188,7 +192,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 				r.Values[i] = compute(v, denomValue)
 			}
 		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 	return results, nil
 }


### PR DESCRIPTION
This PR addresses a bug with the  *seriesLists functions, such as divideSeriesList. This function has been returning an error if the step times of the numerator and denominator are not equal, or if the length of the values in each series are not equal. This is not consistent with [Graphite web's implementation](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L1081), which finds the LCM of the step and then consolidates based on that step time. The numerators and denominators should now be aligned by step, and should be aligned when the number of values are different, and no error should be returned for mismatched step times or value lengths between series.