### PR TITLE
Uncomment 1.19 go tests in workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,7 @@ jobs:
       matrix:
         go:
           - ^1.18
-          # FIXME https://github.com/grafana/carbonapi/issues/70
-          # - ^1.19
+          - ^1.19
           - ^1
     steps:
 


### PR DESCRIPTION
The issue was fixed by the upstream, and we are already in sync. So this should be passing.