### PR TITLE
Check validity of consolidation function in sortBy

### DIFF
--- a/expr/consolidations/consolidations_test.go
+++ b/expr/consolidations/consolidations_test.go
@@ -138,3 +138,41 @@ func TestSummarizeValues(t *testing.T) {
 	}
 
 }
+
+func TestIsValidConsolidationFunc(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedResult bool
+	}{
+		{
+			name:           "sum",
+			expectedResult: true,
+		},
+		{
+			name:           "avg",
+			expectedResult: true,
+		},
+		{
+			name:           "p50",
+			expectedResult: true,
+		},
+		{
+			name:           "p99.9",
+			expectedResult: true,
+		},
+		{
+			name:           "test",
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsValidConsolidationFunc(tt.name)
+			if result != tt.expectedResult {
+				t.Errorf("actual %v, expected %v", result, tt.expectedResult)
+			}
+		})
+	}
+
+}

--- a/expr/consolidations/consolidations_test.go
+++ b/expr/consolidations/consolidations_test.go
@@ -3,6 +3,8 @@ package consolidations
 import (
 	"math"
 	"testing"
+
+	"github.com/ansel1/merry"
 )
 
 func TestSummarizeValues(t *testing.T) {
@@ -139,37 +141,37 @@ func TestSummarizeValues(t *testing.T) {
 
 }
 
-func TestIsValidConsolidationFunc(t *testing.T) {
+func TestCheckValidConsolidationFunc(t *testing.T) {
 	tests := []struct {
 		name           string
-		expectedResult bool
+		expectedResult error
 	}{
 		{
 			name:           "sum",
-			expectedResult: true,
+			expectedResult: nil,
 		},
 		{
 			name:           "avg",
-			expectedResult: true,
+			expectedResult: nil,
 		},
 		{
 			name:           "p50",
-			expectedResult: true,
+			expectedResult: nil,
 		},
 		{
 			name:           "p99.9",
-			expectedResult: true,
+			expectedResult: nil,
 		},
 		{
 			name:           "test",
-			expectedResult: false,
+			expectedResult: ErrInvalidConsolidationFunc,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsValidConsolidationFunc(tt.name)
-			if result != tt.expectedResult {
+			result := CheckValidConsolidationFunc(tt.name)
+			if result != nil && !merry.Is(result, tt.expectedResult) {
 				t.Errorf("actual %v, expected %v", result, tt.expectedResult)
 			}
 		})

--- a/expr/functions/legendValue/function.go
+++ b/expr/functions/legendValue/function.go
@@ -2,6 +2,7 @@ package legendValue
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -59,6 +60,9 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int64, 
 		nameBuf.Grow(len(r.Name) + len(methods)*5)
 		nameBuf.WriteString(r.Name)
 		for _, method := range methods {
+			if !consolidations.IsValidConsolidationFunc(method) {
+				return nil, fmt.Errorf("%s: invalid consolidation function: %s", e.Target(), method)
+			}
 			summary := consolidations.SummarizeValues(method, a.Values, a.XFilesFactor)
 			nameBuf.WriteString(" (")
 			nameBuf.WriteString(method)

--- a/expr/functions/legendValue/function.go
+++ b/expr/functions/legendValue/function.go
@@ -2,7 +2,6 @@ package legendValue
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -49,6 +48,9 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int64, 
 		if method == "si" || method == "binary" {
 			system = method
 		} else {
+			if err := consolidations.CheckValidConsolidationFunc(method); err != nil {
+				return nil, err
+			}
 			methods = append(methods, method)
 		}
 	}
@@ -60,9 +62,6 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int64, 
 		nameBuf.Grow(len(r.Name) + len(methods)*5)
 		nameBuf.WriteString(r.Name)
 		for _, method := range methods {
-			if !consolidations.IsValidConsolidationFunc(method) {
-				return nil, fmt.Errorf("%s: invalid consolidation function: %s", e.Target(), method)
-			}
 			summary := consolidations.SummarizeValues(method, a.Values, a.XFilesFactor)
 			nameBuf.WriteString(" (")
 			nameBuf.WriteString(method)

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -54,6 +54,9 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 	if err != nil {
 		return nil, err
 	}
+	if err := consolidations.CheckValidConsolidationFunc(summarizeFunction); err != nil {
+		return nil, err
+	}
 
 	alignToInterval, err := e.GetStringNamedOrPosArgDefault("alignTo", 3, "")
 	if err != nil {
@@ -112,9 +115,6 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 			}
 
 			if t >= bucketEnd {
-				if !consolidations.IsValidConsolidationFunc(summarizeFunction) {
-					return nil, fmt.Errorf("%s: invalid consolidation function: %s", e.Target(), summarizeFunction)
-				}
 				rv := consolidations.SummarizeValues(summarizeFunction, values, arg.XFilesFactor)
 
 				r.Values[ridx] = rv
@@ -127,9 +127,6 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 
 		// last partial bucket
 		if bucketItems > 0 {
-			if !consolidations.IsValidConsolidationFunc(summarizeFunction) {
-				return nil, fmt.Errorf("%s: invalid consolidation function: %s", e.Target(), summarizeFunction)
-			}
 			rv := consolidations.SummarizeValues(summarizeFunction, values, arg.XFilesFactor)
 			r.Values[ridx] = rv
 		}

--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -112,6 +112,9 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 			}
 
 			if t >= bucketEnd {
+				if !consolidations.IsValidConsolidationFunc(summarizeFunction) {
+					return nil, fmt.Errorf("%s: invalid consolidation function: %s", e.Target(), summarizeFunction)
+				}
 				rv := consolidations.SummarizeValues(summarizeFunction, values, arg.XFilesFactor)
 
 				r.Values[ridx] = rv
@@ -124,6 +127,9 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 
 		// last partial bucket
 		if bucketItems > 0 {
+			if !consolidations.IsValidConsolidationFunc(summarizeFunction) {
+				return nil, fmt.Errorf("%s: invalid consolidation function: %s", e.Target(), summarizeFunction)
+			}
 			rv := consolidations.SummarizeValues(summarizeFunction, values, arg.XFilesFactor)
 			r.Values[ridx] = rv
 		}

--- a/expr/functions/sortBy/function.go
+++ b/expr/functions/sortBy/function.go
@@ -63,8 +63,8 @@ func (f *sortBy) Do(ctx context.Context, e parser.Expr, from, until int64, value
 	if !exists {
 		return nil, fmt.Errorf("invalid function called: %s", target)
 	}
-	if !consolidations.IsValidConsolidationFunc(aggFunc.name) {
-		return nil, fmt.Errorf("%s: invalid consolidation function: %s", target, aggFunc.name)
+	if err := consolidations.CheckValidConsolidationFunc(aggFunc.name); err != nil {
+		return nil, err
 	}
 
 	// some function by default are not ascending so we need to reverse behaviour

--- a/expr/functions/sortBy/function.go
+++ b/expr/functions/sortBy/function.go
@@ -63,6 +63,9 @@ func (f *sortBy) Do(ctx context.Context, e parser.Expr, from, until int64, value
 	if !exists {
 		return nil, fmt.Errorf("invalid function called: %s", target)
 	}
+	if !consolidations.IsValidConsolidationFunc(aggFunc.name) {
+		return nil, fmt.Errorf("%s: invalid consolidation function: %s", target, aggFunc.name)
+	}
 
 	// some function by default are not ascending so we need to reverse behaviour
 	if !aggFunc.ascending {

--- a/expr/functions/sortBy/function_test.go
+++ b/expr/functions/sortBy/function_test.go
@@ -1,6 +1,7 @@
 package sortBy
 
 import (
+	"github.com/go-graphite/carbonapi/expr/consolidations"
 	"testing"
 	"time"
 
@@ -125,4 +126,30 @@ func TestFunction(t *testing.T) {
 		})
 	}
 
+}
+
+func TestErrorInvalidConsolidationFunction(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItemWithError{
+		{
+			"sortBy(metric*, 'test')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					types.MakeMetricData("metricB", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					types.MakeMetricData("metricC", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+				},
+			},
+			nil,
+			consolidations.ErrInvalidConsolidationFunc,
+		},
+	}
+
+	for _, testCase := range tests {
+		testName := testCase.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithError(t, &testCase)
+		})
+	}
 }

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -56,6 +56,9 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 	if !funcOk {
 		funcOk = e.ArgsLen() > 2
 	}
+	if err := consolidations.CheckValidConsolidationFunc(summarizeFunction); err != nil {
+		return nil, err
+	}
 
 	alignToFrom, err := e.GetBoolNamedOrPosArgDefault("alignToFrom", 3, false)
 	if err != nil {
@@ -145,9 +148,6 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			}
 
 			if t >= bucketEnd {
-				if !consolidations.IsValidConsolidationFunc(summarizeFunction) {
-					return nil, fmt.Errorf("%s: invalid consolidation function: %s", e.Target(), summarizeFunction)
-				}
 				rv := consolidations.SummarizeValues(summarizeFunction, values, arg.XFilesFactor)
 
 				r.Values[ridx] = rv
@@ -160,9 +160,6 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 
 		// last partial bucket
 		if bucketItems > 0 {
-			if !consolidations.IsValidConsolidationFunc(summarizeFunction) {
-				return nil, fmt.Errorf("%s: invalid consolidation function: %s", e.Target(), summarizeFunction)
-			}
 			rv := consolidations.SummarizeValues(summarizeFunction, values, arg.XFilesFactor)
 			r.Values[ridx] = rv
 		}

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -145,6 +145,9 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			}
 
 			if t >= bucketEnd {
+				if !consolidations.IsValidConsolidationFunc(summarizeFunction) {
+					return nil, fmt.Errorf("%s: invalid consolidation function: %s", e.Target(), summarizeFunction)
+				}
 				rv := consolidations.SummarizeValues(summarizeFunction, values, arg.XFilesFactor)
 
 				r.Values[ridx] = rv
@@ -157,6 +160,9 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 
 		// last partial bucket
 		if bucketItems > 0 {
+			if !consolidations.IsValidConsolidationFunc(summarizeFunction) {
+				return nil, fmt.Errorf("%s: invalid consolidation function: %s", e.Target(), summarizeFunction)
+			}
 			rv := consolidations.SummarizeValues(summarizeFunction, values, arg.XFilesFactor)
 			r.Values[ridx] = rv
 		}


### PR DESCRIPTION
This PR fixes a bug found in the sortBy() function, in which the specified consolidation function was not checked to verify that it was a valid function. This would cause a panic to occur, because in consolidations.SummarizeValues, the default case in the switch statement involves a string split which assumes that the consolidation function is 'p50'-'p999'. If the specified consolidation function was not 'p50'-'p999', then the panic would occur on the string split.