### PR TITLE
Prevent panic in fallbackSeries function if only one argument is provided

### DIFF
--- a/expr/functions/fallbackSeries/function.go
+++ b/expr/functions/fallbackSeries/function.go
@@ -33,6 +33,10 @@ func (f *fallbackSeries) Do(ctx context.Context, e parser.Expr, from, until int6
 		Takes a wildcard seriesList, and a second fallback metric.
 		If the wildcard does not match any series, draws the fallback metric.
 	*/
+	if e.ArgsLen() < 2 {
+		return nil, parser.ErrMissingTimeseries
+	}
+
 	seriesList, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	fallback, errFallback := helper.GetSeriesArg(ctx, e.Arg(1), from, until, values)
 	if errFallback != nil && err != nil {

--- a/expr/functions/fallbackSeries/function_test.go
+++ b/expr/functions/fallbackSeries/function_test.go
@@ -74,3 +74,29 @@ func TestFallbackSeries(t *testing.T) {
 	}
 
 }
+
+func TestErrorMissingTimeSeriesFunction(t *testing.T) {
+	now32 := int64(time.Now().Unix())
+
+	tests := []th.EvalTestItemWithError{
+		{
+			"fallbackSeries(metric*)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
+					types.MakeMetricData("metricB", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					types.MakeMetricData("metricC", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
+				},
+			},
+			nil,
+			parser.ErrMissingTimeseries,
+		},
+	}
+
+	for _, testCase := range tests {
+		testName := testCase.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithError(t, &testCase)
+		})
+	}
+}


### PR DESCRIPTION
If only one seriesList is provided to the fallbackSeries function, a panic occurs when helper.getSeriesArg() is called. Instead, an ErrMissingTimeSeries is now returned in order to prevent the panic.