### PR TITLE
Consolidate series by step for divideSeries

### DIFF
--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -80,16 +80,6 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		return nil, errors.New("must be called with 2 series or a wildcard that matches exactly 2 series")
 	}
 
-	alignedSeries := helper.AlignSeries(types.CopyMetricDataSlice(append(numerators, denominator)))
-	numerators = alignedSeries[:len(numerators)]
-	denominator = alignedSeries[len(numerators)]
-
-	for _, numerator := range numerators {
-		if numerator.StepTime != denominator.StepTime {
-			return nil, fmt.Errorf("series %s must have the same length as %s", numerator.Name, denominator.Name)
-		}
-	}
-
 	for _, numerator := range numerators {
 		var name string
 		if useMetricNames {
@@ -97,11 +87,13 @@ func (f *divideSeries) Do(ctx context.Context, e parser.Expr, from, until int64,
 		} else {
 			name = "divideSeries(" + e.RawArgs() + ")"
 		}
+
+		numerator, denominator = helper.ConsolidateSeriesByStep(numerator, denominator)
+
 		r := numerator.CopyTag(name, numerator.Tags)
 		r.Values = make([]float64, len(numerator.Values))
 
 		for i, v := range numerator.Values {
-
 			// math.IsNaN(v) || math.IsNaN(denominator.Values[i]) covered by nature of math.NaN
 			if denominator.Values[i] == 0 {
 				r.Values[i] = math.NaN()

--- a/expr/functions/divideSeries/function_test.go
+++ b/expr/functions/divideSeries/function_test.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func TestDivideSeriesMultiReturn(t *testing.T) {
-	now32 := int64(time.Now().Unix())
+	now32 := time.Now().Unix()
 
 	tests := []th.MultiReturnEvalTestItem{
 		{
@@ -57,7 +57,7 @@ func TestDivideSeriesMultiReturn(t *testing.T) {
 }
 
 func TestDivideSeries(t *testing.T) {
-	now32 := int64(time.Now().Unix())
+	now32 := time.Now().Unix()
 
 	tests := []th.EvalTestItem{
 		{
@@ -99,39 +99,57 @@ func TestDivideSeries(t *testing.T) {
 }
 
 func TestDivideSeriesAligned(t *testing.T) {
-	now32 := int64(time.Now().Unix())
+	startTime := int64(0)
 
-	tests := []th.EvalTestItem{
+	tests := []th.EvalTestItemWithRange{
 		{
 			"divideSeries(metric1,metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {
-					types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, now32),
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, startTime),
 				},
 				{"metric2", 0, 1}: {
-					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, startTime),
 				},
 			},
 			[]*types.MetricData{types.MakeMetricData("divideSeries(metric1,metric2)",
-				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, math.NaN()}, 1, now32)},
+				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, math.NaN()}, 1, startTime)},
+			startTime,
+			startTime + 1,
 		},
 		{
 			"divideSeries(metric[23])",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric[23]", 0, 1}: {
-					types.MakeMetricData("metric2", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, now32),
-					types.MakeMetricData("metric3", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, now32),
+					types.MakeMetricData("metric2", []float64{1, math.NaN(), math.NaN(), 3, 4, 12, 2}, 1, startTime),
+					types.MakeMetricData("metric3", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 1, startTime),
 				},
 			},
 			[]*types.MetricData{types.MakeMetricData("divideSeries(metric[23])",
-				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, math.NaN()}, 1, now32).SetNameTag("metric2")},
+				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, math.NaN()}, 1, startTime).SetNameTag("metric2")},
+			startTime,
+			startTime + 1,
+		},
+		{
+			"divideSeries(metric3,metric4)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric3", 0, 1}: {
+					types.MakeMetricData("metric3", []float64{1, math.NaN(), math.NaN(), 3, 4, 8, 2, math.NaN(), 3, math.NaN(), 0, 6}, 5, startTime),
+				},
+				{"metric4", 0, 1}: {
+					types.MakeMetricData("metric4", []float64{2, math.NaN(), 3, math.NaN(), 0, 6}, 10, startTime),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("divideSeries(metric3,metric4)",
+				[]float64{0.5, math.NaN(), 2, math.NaN(), math.NaN(), 0.5}, 10, startTime)},
+			startTime,
+			startTime + 1,
 		},
 	}
 
 	for _, tt := range tests {
-		testName := tt.Target
-		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
+		t.Run(tt.Target, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
 		})
 	}
 }

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -150,13 +150,7 @@ func (f *seriesList) Do(ctx context.Context, e parser.Expr, from, until int64, v
 			}
 		}
 		if pairFound {
-			pair := []*types.MetricData{numerator, denominator}
-			step, alignStep := helper.GetCommonStep(pair)
-			if alignStep || len(numerator.Values) != len(denominator.Values) {
-				alignedSeries := helper.ScaleToCommonStep(types.CopyMetricDataSlice(pair), step)
-				numerator = alignedSeries[0]
-				denominator = alignedSeries[1]
-			}
+			numerator, denominator = helper.ConsolidateSeriesByStep(numerator, denominator)
 		}
 
 		r := numerator.CopyLink()

--- a/expr/helper/align.go
+++ b/expr/helper/align.go
@@ -75,7 +75,7 @@ func GetStepRange(args []*types.MetricData) (minStep, maxStep int64, needScale b
 // It respects xFilesFactor and fills gaps in the begin and end with NaNs if needed.
 func ScaleToCommonStep(args []*types.MetricData, commonStep int64) []*types.MetricData {
 	if commonStep < 0 || len(args) == 0 {
-		// This doesn't make sence
+		// This doesn't make sense
 		return args
 	}
 
@@ -377,6 +377,21 @@ func ScaleSeries(args []*types.MetricData) []*types.MetricData {
 	}
 
 	return args
+}
+
+func ConsolidateSeriesByStep(numerator, denominator *types.MetricData) (*types.MetricData, *types.MetricData) {
+	pair := []*types.MetricData{numerator, denominator}
+
+	step, changed := GetCommonStep(pair)
+	if changed || len(numerator.Values) != len(denominator.Values) {
+		alignedSeries := ScaleToCommonStep(types.CopyMetricDataSlice(pair), step)
+		numerator = alignedSeries[0]
+		denominator = alignedSeries[1]
+
+		return alignedSeries[0], alignedSeries[1]
+	}
+
+	return numerator, denominator
 }
 
 func genNaNs(length int) []float64 {


### PR DESCRIPTION
This PR expands the fix in https://github.com/grafana/carbonapi/pull/99 to `divideSeries`.