### PR TITLE
Prevent panic in removeEmptySeries if series is nil and xFilesFactor is specified

### DIFF
--- a/expr/functions/removeEmptySeries/function.go
+++ b/expr/functions/removeEmptySeries/function.go
@@ -37,6 +37,9 @@ func (f *removeEmptySeries) Do(ctx context.Context, e parser.Expr, from, until i
 	if err != nil {
 		return nil, err
 	}
+	if len(args) == 0 {
+		return []*types.MetricData{}, nil
+	}
 
 	if len(e.Args()) == 2 {
 		xFilesFactor, err = e.GetFloatArgDefault(1, float64(args[0].XFilesFactor)) // If set by setXFilesFactor, all series in a list will have the same value

--- a/expr/functions/removeEmptySeries/function_test.go
+++ b/expr/functions/removeEmptySeries/function_test.go
@@ -137,6 +137,16 @@ func TestFunction(t *testing.T) {
 				types.MakeMetricData("metric1", []float64{1, 2, -1, 7, 8, 20, 23, 12, 8, -2.3}, 1, now32),
 			},
 		},
+		{
+			"removeEmptySeries(metric*,0.5)", // Verify that passing in empty series with an xFilesFactor does not result in an error
+			nil,
+			[]*types.MetricData{},
+		},
+		{
+			"removeZeroSeries(metric*,0.5)", // Verify that passing in empty series with an xFilesFactor does not result in an error
+			nil,
+			[]*types.MetricData{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes a panic that was occurring when removeEmptySeries or removeBelowSeries was called with a series that is nil as well as an xFilesFactor argument. The panic was occurring when the xFilesFactor argument was attempting to be accessed: `args[0].XFilesFactor`. If args[0] is nil, a `runtime error: index out of range [0] with length 0.` error is thrown. To prevent this, if the series argument has a length of 0, an empty series is returned.