### PR TITLE
Fix GetIntervalNamedOrPosArgDefault

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -240,7 +240,7 @@ func (e *expr) GetIntervalNamedOrPosArgDefault(k string, n, defaultSign int, v i
 	var val string
 	var err error
 	if a := e.getNamedArg(k); a != nil {
-		val, err = e.doGetStringArg()
+		val, err = a.doGetStringArg()
 		if err != nil {
 			return 0, ErrBadType
 		}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -450,6 +450,15 @@ func TestDoGetFloatArg(t *testing.T) {
 	}
 }
 
+func TestGetIntervalNamedOrPosArgDefault(t *testing.T) {
+	e, _, err := ParseExpr("func(metric, key='1sec')")
+	assert.NoError(t, err)
+
+	val, err := e.GetIntervalNamedOrPosArgDefault("key", 1, -1, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, -1, val)
+}
+
 func TestDoGetIntArg(t *testing.T) {
 	tests := []struct {
 		s string

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -451,12 +451,12 @@ func TestDoGetFloatArg(t *testing.T) {
 }
 
 func TestGetIntervalNamedOrPosArgDefault(t *testing.T) {
-	e, _, err := ParseExpr("func(metric, key='1sec')")
+	e, _, err := ParseExpr("func(metric, key='1min')")
 	assert.NoError(t, err)
 
 	val, err := e.GetIntervalNamedOrPosArgDefault("key", 1, -1, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, -1, val)
+	assert.Equal(t, int64(-60), val)
 }
 
 func TestDoGetIntArg(t *testing.T) {


### PR DESCRIPTION
The diff says it all, the wrong `expr` was being used.