### PR TITLE
Add support for Graphite web compressPeriodicGaps function

### DIFF
--- a/expr/functions/compressPeriodicGaps/function.go
+++ b/expr/functions/compressPeriodicGaps/function.go
@@ -1,0 +1,150 @@
+package compressPeriodicGaps
+
+import (
+	"context"
+	"github.com/go-graphite/carbonapi/expr/consolidations"
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/interfaces"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+	"math"
+)
+
+type compressPeriodicGaps struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &compressPeriodicGaps{}
+	functions := []string{"compressPeriodicGaps"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// compressPeriodicGaps(seriesList)
+func (f *compressPeriodicGaps) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	args, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+	var results []*types.MetricData
+
+	for _, a := range args {
+		firstSeen := -1
+		secondSeen := -1
+		interval := math.NaN()
+		name := "compressPeriodicGaps(" + e.Target() + ")"
+
+		for i, v := range a.Values {
+			if !math.IsNaN(v) {
+				if firstSeen >= 0 {
+					secondSeen = i
+					break
+				} else {
+					firstSeen = i
+				}
+			}
+		}
+		stepGuess := secondSeen - firstSeen
+		thirdSeen := secondSeen + stepGuess
+		if stepGuess > 1 && thirdSeen <= len(a.Values)-2 {
+			if !math.IsNaN(a.Values[thirdSeen]) {
+				if math.IsNaN(a.Values[thirdSeen-1]) && math.IsNaN(a.Values[thirdSeen+1]) {
+					interval = float64(int64(stepGuess) * a.StepTime)
+				}
+			}
+		}
+
+		if math.IsNaN(interval) {
+			r := a.CopyLink()
+			r.Name = name
+			results = append(results, r)
+		} else {
+			buckets := helper.GetBuckets(a.StartTime, a.StopTime, int64(interval))
+
+			newStart := a.StartTime + int64(firstSeen)*a.StepTime
+			newValues := make([]float64, 0, int64(interval)/a.StepTime)
+			ridx := 0
+			intervalItems := 0
+			intervalEnd := float64(newStart) + interval
+			t := a.StartTime // unadjusted
+			r := types.MetricData{
+				FetchResponse: pb.FetchResponse{
+					Name:              name,
+					Values:            make([]float64, buckets),
+					StepTime:          int64(interval),
+					StartTime:         newStart,
+					StopTime:          a.StopTime,
+					XFilesFactor:      a.XFilesFactor,
+					PathExpression:    a.PathExpression,
+					ConsolidationFunc: a.ConsolidationFunc,
+				},
+				Tags: helper.CopyTags(a),
+			}
+
+			for _, v := range a.Values {
+				intervalItems++
+				if !math.IsNaN(v) {
+					newValues = append(newValues, v)
+				}
+
+				t += a.StepTime
+
+				if t >= a.StopTime {
+					break
+				}
+
+				if t >= int64(intervalEnd) {
+					rv := consolidations.SummarizeValues("last", newValues, a.XFilesFactor)
+
+					r.Values[ridx] = rv
+					ridx++
+					intervalEnd += interval
+					intervalItems = 0
+					newValues = newValues[:0]
+				}
+			}
+
+			// last partial bucket
+			if intervalItems > 0 {
+				rv := consolidations.SummarizeValues("last", newValues, a.XFilesFactor)
+				r.Values[ridx] = rv
+			}
+
+			newEnd := newStart + int64(interval)*int64(len(newValues)-1)
+			r.StopTime = newEnd
+			results = append(results, &r)
+		}
+
+	}
+
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *compressPeriodicGaps) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"compressPeriodicGaps": {
+			Description: "Tries to intelligently remove periodic None’s from series, recalculating start, stop and step values.\n You can use summarize(seriesList, ‘<desired step>’, ‘last’) function for that also, but this function trying to guess desired step automatically.\n Can be used in case of fix metric with improper resolution. Especially useful for derivative functions, which are not working with series with regular gaps.\n\n.. code-block:: none\n\n &target=compressPeriodicGaps(Server.instance01.threads.busy)\n\n",
+			Function:    "compressPeriodicGaps(seriesList)",
+			Group:       "Special",
+			Module:      "graphite.render.functions",
+			Name:        "compressPeriodicGaps",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/compressPeriodicGaps/function_test.go
+++ b/expr/functions/compressPeriodicGaps/function_test.go
@@ -1,0 +1,63 @@
+package compressPeriodicGaps
+
+import (
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+	"math"
+	"testing"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestCompressPeriodicGaps(t *testing.T) {
+	var startTime int64 = 100
+
+	tests := []th.EvalTestItemWithRange{
+		{
+			Target: `compressPeriodicGaps(metric*)`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric*", From: startTime, Until: startTime + 160}: {
+					types.MakeMetricData("metric1", []float64{math.NaN(), 1, math.NaN(), math.NaN(), 2, math.NaN(), math.NaN(), 3, math.NaN(), math.NaN(), 4, math.NaN(), math.NaN(), 5, math.NaN(), math.NaN()}, 10, startTime),
+					types.MakeMetricData("metric2", []float64{1, math.NaN(), math.NaN(), 2, math.NaN(), math.NaN(), 3, math.NaN(), math.NaN(), 4, math.NaN(), math.NaN(), 5, math.NaN(), math.NaN(), 6}, 10, startTime+10),
+					types.MakeMetricData("metric3", []float64{math.NaN(), math.NaN(), 1, math.NaN(), math.NaN(), 2, math.NaN(), math.NaN(), 3, math.NaN(), math.NaN(), 4, math.NaN(), math.NaN(), 5, math.NaN()}, 10, startTime),
+					types.MakeMetricData("metric4", []float64{math.NaN(), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 13, math.NaN()}, 10, startTime),
+					types.MakeMetricData("metric5", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, 10, startTime),
+					types.MakeMetricData("metric6", []float64{math.NaN(), 1, math.NaN(), 3, math.NaN(), 5, math.NaN(), 7, math.NaN(), 9, math.NaN(), 11, math.NaN(), 13, math.NaN(), 15}, 10, startTime),
+					types.MakeMetricData("metric7", []float64{math.NaN(), 1, 2, 3, math.NaN(), 5, math.NaN(), 7, math.NaN(), 9, math.NaN(), math.NaN(), math.NaN(), 13, math.NaN(), math.NaN()}, 10, startTime),
+					types.MakeMetricData("metric8", []float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 13, 14, 15}, 10, startTime),
+				},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("compressPeriodicGaps(metric1)", []float64{1, 2, 3, 4, 5}, 30, startTime+10),
+				types.MakeMetricData("compressPeriodicGaps(metric2)", []float64{1, 2, 3, 4, 5, 6}, 30, startTime+10),
+				types.MakeMetricData("compressPeriodicGaps(metric3)", []float64{1, 2, 3, 4, 5}, 30, startTime+20),
+				types.MakeMetricData("compressPeriodicGaps(metric4)", []float64{math.NaN(), 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 13, math.NaN()}, 10, startTime),
+				types.MakeMetricData("compressPeriodicGaps(metric5)", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, 10, startTime),
+				types.MakeMetricData("compressPeriodicGaps(metric6)", []float64{1, 3, 5, 7, 9, 11, 13, 15}, 20, startTime+10),
+				types.MakeMetricData("compressPeriodicGaps(metric7)", []float64{math.NaN(), 1, 2, 3, math.NaN(), 5, math.NaN(), 7, math.NaN(), 9, math.NaN(), math.NaN(), math.NaN(), 13, math.NaN(), math.NaN()}, 10, startTime),
+				types.MakeMetricData("compressPeriodicGaps(metric8)", []float64{1, 2, 3, math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 13, 14, 15}, 10, startTime),
+			},
+			From:  startTime,
+			Until: 260,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
+		})
+	}
+
+}

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-graphite/carbonapi/expr/functions/cactiStyle"
 	"github.com/go-graphite/carbonapi/expr/functions/cairo"
 	"github.com/go-graphite/carbonapi/expr/functions/changed"
+	"github.com/go-graphite/carbonapi/expr/functions/compressPeriodicGaps"
 	"github.com/go-graphite/carbonapi/expr/functions/consolidateBy"
 	"github.com/go-graphite/carbonapi/expr/functions/constantLine"
 	"github.com/go-graphite/carbonapi/expr/functions/cumulative"
@@ -150,6 +151,7 @@ func New(configs map[string]string) {
 		{name: "cactiStyle", filename: "cactiStyle", order: cactiStyle.GetOrder(), f: cactiStyle.New},
 		{name: "cairo", filename: "cairo", order: cairo.GetOrder(), f: cairo.New},
 		{name: "changed", filename: "changed", order: changed.GetOrder(), f: changed.New},
+		{name: "compressPeriodicGaps", filename: "compressPeriodicGaps", order: compressPeriodicGaps.GetOrder(), f: compressPeriodicGaps.New},
 		{name: "consolidateBy", filename: "consolidateBy", order: consolidateBy.GetOrder(), f: consolidateBy.New},
 		{name: "constantLine", filename: "constantLine", order: constantLine.GetOrder(), f: constantLine.New},
 		{name: "cumulative", filename: "cumulative", order: cumulative.GetOrder(), f: cumulative.New},


### PR DESCRIPTION
This PR adds support for the Graphite web compressPeriodicGaps function. This function is defined as:

```
compressPeriodicGaps(seriesList)
Tries to intelligently remove periodic None’s from series, recalculating start, stop and step values. You can use summarize(seriesList, ‘<desired step>’, ‘last’) function for that also, but this function trying to guess desired step automatically. Can be used in case of fix metric with improper resolution. Especially useful for derivative functions, which are not working with series with regular gaps.

Example:

&target=compressPeriodicGaps(Server.instance01.threads.busy)
```

Graphite web's implementation can be found [here](https://github.com/graphite-project/graphite-web/blob/b52987ac97f49dcfb401a21d4b92860cfcbcf074/webapp/graphite/render/functions.py#L5909)