### PR TITLE
Fix hitcount function handling of intervals and alignToInterval

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -31,12 +31,12 @@ func (eval evaluator) FetchAndEvalExprs(ctx context.Context, exprs []parser.Expr
 
 	haveFallbackSeries := false
 	for _, exp := range exprs {
-		for _, m := range exp.Metrics() {
+		for _, m := range exp.Metrics(from, until) {
 			fetchRequest := pb.FetchRequest{
 				Name:           m.Metric,
 				PathExpression: m.Metric,
-				StartTime:      m.From + from,
-				StopTime:       m.Until + until,
+				StartTime:      m.From,
+				StopTime:       m.Until,
 				MaxDataPoints:  maxDataPoints,
 			}
 			metricRequest := parser.MetricRequest{
@@ -126,7 +126,7 @@ func (eval evaluator) FetchAndEvalExp(ctx context.Context, exp parser.Expr, from
 	// values related to this particular `target=`
 	targetValues := make(map[parser.MetricRequest][]*types.MetricData)
 
-	for _, m := range exp.Metrics() {
+	for _, m := range exp.Metrics(from, until) {
 		fetchRequest := pb.FetchRequest{
 			Name:           m.Metric,
 			PathExpression: m.Metric,

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -130,8 +130,8 @@ func (eval evaluator) FetchAndEvalExp(ctx context.Context, exp parser.Expr, from
 		fetchRequest := pb.FetchRequest{
 			Name:           m.Metric,
 			PathExpression: m.Metric,
-			StartTime:      m.From + from,
-			StopTime:       m.Until + until,
+			StartTime:      m.From,
+			StopTime:       m.Until,
 			MaxDataPoints:  maxDataPoints,
 		}
 		metricRequest := parser.MetricRequest{

--- a/expr/functions/hitcount/function_test.go
+++ b/expr/functions/hitcount/function_test.go
@@ -55,10 +55,11 @@ func TestHitcount(t *testing.T) {
 					math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(),
 					5}, 5, now32)},
 			},
-			[]float64{35, 70, 105, 140, math.NaN(), 25},
+			[]float64{5, 40, 75, 110, 120, 25},
+
 			"hitcount(metric1,'30s')",
 			30,
-			now32,
+			1410344975,
 			now32 + 31*5,
 		},
 		{
@@ -72,7 +73,7 @@ func TestHitcount(t *testing.T) {
 			[]float64{375},
 			"hitcount(metric1,'1h')",
 			3600,
-			tenFiftyNine,
+			1410343265,
 			tenFiftyNine + 25*5,
 		},
 		{
@@ -83,11 +84,11 @@ func TestHitcount(t *testing.T) {
 					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
 					5}, 5, tenFiftyNine)},
 			},
-			[]float64{105, 270},
+			[]float64{375},
 			"hitcount(metric1,'1h',true)",
 			3600,
-			tenFiftyNine - (59 * 60),
-			tenFiftyNine + 25*5,
+			tenFiftyNine,
+			tenFiftyNine + (((tenFiftyNine + 25*5) - tenFiftyNine) / 3600) + 3600, // The end time is adjusted because of alignToInterval being set to true
 		},
 		{
 			"hitcount(metric1,\"1h\",alignToInterval=true)",
@@ -97,11 +98,24 @@ func TestHitcount(t *testing.T) {
 					3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5,
 					5}, 5, tenFiftyNine)},
 			},
-			[]float64{105, 270},
+			[]float64{375},
 			"hitcount(metric1,'1h',true)",
 			3600,
-			tenFiftyNine - (59 * 60),
-			tenFiftyNine + 25*5,
+			tenFiftyNine,
+			tenFiftyNine + (((tenFiftyNine + 25*5) - tenFiftyNine) / 3600) + 3600, // The end time is adjusted because of alignToInterval being set to true
+		},
+		{
+			"hitcount(metric1,\"15s\")", // Test having a smaller interval than the data's step
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
+					11, 7, 19, 32, 23}, 30, now32)},
+			},
+			[]float64{165, 165, 105, 105, 285, 285, 480, 480, 345, 345},
+
+			"hitcount(metric1,'15s')",
+			15,
+			now32,
+			now32 + 5*30,
 		},
 	}
 

--- a/expr/helper/align.go
+++ b/expr/helper/align.go
@@ -401,3 +401,9 @@ func genNaNs(length int) []float64 {
 	}
 	return nans
 }
+
+func Divmod(numerator, denominator int64) (quotient, remainder int64) {
+	quotient = numerator / denominator // integer division, decimals are truncated
+	remainder = numerator % denominator
+	return
+}

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -108,7 +108,7 @@ type Expr interface {
 	MutateRawArgs(args string) Expr
 
 	// Metrics returns list of metric requests
-	Metrics() []MetricRequest
+	Metrics(from, until int64) []MetricRequest
 
 	// GetIntervalArg returns interval typed argument.
 	GetIntervalArg(n int, defaultSign int) (int32, error)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -497,3 +497,94 @@ func TestDoGetIntArg(t *testing.T) {
 		})
 	}
 }
+
+func TestMetrics(t *testing.T) {
+	tests := []struct {
+		s        string
+		e        *expr
+		from     int64
+		to       int64
+		expected []MetricRequest
+	}{
+		{
+			"hitcount(metric1, '1h', true)",
+			&expr{
+				target: "hitcount",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1h", etype: EtString},
+					{valStr: "true", etype: EtBool},
+				},
+				argString: "metric1, '1h', true",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410343200,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
+			"hitcount(metric1, '1h')",
+			&expr{
+				target: "hitcount",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1h", etype: EtString},
+				},
+				argString: "metric1, '1h'",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410346740,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
+			"hitcount(timeShift(metric1, '-1h'),'1h')",
+			&expr{
+				target: "hitcount",
+				etype:  EtFunc,
+				args: []*expr{
+					{
+						target: "timeShift",
+						etype:  EtFunc,
+						args: []*expr{
+							{target: "metric1"},
+							{valStr: "-1h", etype: EtString},
+						},
+						argString: "metric1, '-1h'",
+					},
+					{valStr: "1h", etype: EtString},
+					{valStr: "true", etype: EtBool},
+				},
+				argString: "timeShift(metric1, '-1h'),'1h'",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410339600,
+					Until:  1410343265,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+
+			r := tt.e.Metrics(tt.from, tt.to)
+			assert.Equal(t, tt.expected, r)
+		})
+	}
+}


### PR DESCRIPTION
This PR is a rewrite of the hitcount function in order to match Graphite web's behavior. There are two major issues that were discovered: 

1) When the `interval` parameter was set to a value smaller than the fetched data's step between data points, it results were incorrectly shifted left, such that all of the hit counts were concentrated towards the left buckets, and there were empty buckets on the right. For example:

hitcount(metric1, "6m")
[]*types.MetricData{{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6}, 600, 100)},} // 10m step

The result will be []float64{1200, 2400, 3600, 0, 0, 0}. The hit values are all concentrated on the left half of the buckets.

2) Upon looking at Graphite web's implementation of hitcount, when the `alignToInterval` parameter is set to true, the start time is adjusted and the data is re-fetched. In CarbonAPI, the start time was adjusted, but data was not re-fetched. 

**Major changes in this PR:**
- The hitcount function was completely rewritten to match the behavior of Graphite web. This helps address the issue with intervals smaller than the data's step, as well as fixes discrepancies in results that were occurring with CarbonAPI tests that were tested in Graphite web. 
- The Metrics() function in pkg/parser.go was updated to pass in the from/to of the request, and code was added to determine the correct start time for the data being fetched for the hitcount function when `alignToInterval ` is set to true. The new start time is determined based on the request's from value and the interval specified. This is intended to prevent needing to re-fetch the data as is done in Graphite web. 