### PR TITLE
Adjust the from value before getting series arg in hitcount

### DIFF
--- a/expr/functions/hitcount/function.go
+++ b/expr/functions/hitcount/function.go
@@ -38,15 +38,6 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 		return nil, parser.ErrMissingArgument
 	}
 
-	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(args) == 0 {
-		return []*types.MetricData{}, nil
-	}
-
 	bucketSizeInt32, err := e.GetIntervalArg(1, 1)
 	if err != nil {
 		return nil, err
@@ -56,6 +47,20 @@ func (f *hitcount) Do(ctx context.Context, e parser.Expr, from, until int64, val
 	alignToInterval, err := e.GetBoolNamedOrPosArgDefault("alignToInterval", 2, false)
 	if err != nil {
 		return nil, err
+	}
+
+	if alignToInterval {
+		// from needs to be adjusted before grabbing the series arg as it has been adjusted in the metric request
+		from = helper.AlignStartToInterval(from, until, interval)
+	}
+
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(args) == 0 {
+		return []*types.MetricData{}, nil
 	}
 
 	start := args[0].StartTime


### PR DESCRIPTION
This PR fixes an issue in hitcount. If alignToInterval is set to true, then the from value needs to be adjusted to the new start time before the call to getSeriesArg; otherwise, the from is set to the pre-adjusted value. This is similar to how it is done in other functions with adjusted start times, such as timeShift, where an offset is added to the from value before calling getSeriesArg.