### PR TITLE
Fix parsing of alignToInterval named arg in parser

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -217,32 +217,32 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 				return nil
 			}
 
-			if len(e.args) == 3 {
-				alignToInterval, err := e.GetBoolNamedOrPosArgDefault("alignToInterval", 2, false)
+			alignToInterval, err := e.GetBoolNamedOrPosArgDefault("alignToInterval", 2, false)
+			if err != nil {
+				return nil
+			}
+			if alignToInterval {
+				bucketSizeInt32, err := e.GetIntervalArg(1, 1)
 				if err != nil {
 					return nil
 				}
-				if alignToInterval {
-					bucketSizeInt32, err := e.GetIntervalArg(1, 1)
-					if err != nil {
-						return nil
-					}
-					interval := int64(bucketSizeInt32)
-					// This is done in order to replicate the behavior in Graphite web when alignToInterval is set,
-					// in which new data is fetched with the adjusted start time.
-					for i, _ := range r {
-						start := r[i].From
-						for _, v := range []int64{86400, 3600, 60} {
-							if interval >= v {
-								start -= start % v
-								break
-							}
-						}
 
-						r[i].From = start
+				interval := int64(bucketSizeInt32)
+				// This is done in order to replicate the behavior in Graphite web when alignToInterval is set,
+				// in which new data is fetched with the adjusted start time.
+				for i, _ := range r {
+					start := r[i].From
+					for _, v := range []int64{86400, 3600, 60} {
+						if interval >= v {
+							start -= start % v
+							break
+						}
 					}
+
+					r[i].From = start
 				}
 			}
+
 		}
 		return r
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -529,6 +529,34 @@ func TestMetrics(t *testing.T) {
 			},
 		},
 		{
+			"hitcount(metric1, '1h', alignToInterval=True)",
+			&expr{
+				target: "hitcount",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1h", etype: EtString},
+				},
+				namedArgs: map[string]*expr{
+					"alignToInterval": {
+						target: "true",
+						etype:  EtBool,
+						valStr: "true",
+					},
+				},
+				argString: "metric1, '1h', alignToInterval=True",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410343200,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
 			"hitcount(metric1, '1h')",
 			&expr{
 				target: "hitcount",


### PR DESCRIPTION
This PR fixes handling of the named alignToInterval argument in parser.go for adjusting the start time of the metric request. Previously, there was a check if there were 3 args before trying to determine the alignToInterval value. However, because in this case it is a named argument, it is stored in a different field in the expression than the other function arguments are. Therefore, the length of e.args() in this case was 2, so the adjustment of the start time was not occurring.