### PR TITLE
Fix smartSummarize to properly handle alignTo start time and intervals smaller than data StepTime

### DIFF
--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -1,6 +1,7 @@
 package smartSummarize
 
 import (
+	"math"
 	"testing"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -129,6 +130,62 @@ func TestEvalSummarize(t *testing.T) {
 			60,
 			0,
 			240,
+		},
+		{
+			"smartSummarize(metric1,'4hours','sum','weeks')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+			},
+			[]float64{103672800},
+			"smartSummarize(metric1,'4hours','sum','weeks')",
+			14400,
+			0,
+			14400,
+		},
+		{
+			"smartSummarize(metric1,'1d','sum','days')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 86400, 60), 60, 0)},
+			},
+			[]float64{62164800},
+			"smartSummarize(metric1,'1d','sum','days')",
+			86400,
+			0,
+			86400,
+		},
+		{
+			"smartSummarize(metric1,'1minute','sum','seconds')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 240, 1), 1, 0)},
+			},
+			[]float64{1770, 5370, 8970, 12570},
+			"smartSummarize(metric1,'1minute','sum','seconds')",
+			60,
+			0,
+			240,
+		},
+		{
+			"smartSummarize(metric1,'1hour','max','hours')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", generateValues(0, 14400, 1), 1, 0)},
+			},
+			[]float64{3599, 7199, 10799, 14399},
+			"smartSummarize(metric1,'1hour','max','hours')",
+			3600,
+			0,
+			14400,
+		},
+		{
+			"smartSummarize(metric1,'6m','sum', 'minutes')", // Test having a smaller interval than the data's step
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{
+					2, 4, 6}, 600, 1410345000)},
+			},
+			[]float64{2, 4, math.NaN(), 6, math.NaN()},
+			"smartSummarize(metric1,'6m','sum','minutes')",
+			360,
+			1410345000,
+			1410345000 + 3*600,
 		},
 	}
 

--- a/expr/functions/smartSummarize/function_test.go
+++ b/expr/functions/smartSummarize/function_test.go
@@ -187,6 +187,17 @@ func TestEvalSummarize(t *testing.T) {
 			1410345000,
 			1410345000 + 3*600,
 		},
+		{
+			"smartSummarize(metric2,'2minute','sum')",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{1, 2, 3, 4}, 60, 0)},
+			},
+			[]float64{3, 7},
+			"smartSummarize(metric2,'2minute','sum')",
+			120,
+			0,
+			240,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -48,6 +48,8 @@ var (
 	ErrUnknownTimeUnits = errors.New("unknown time units")
 	// ErrInvalidArg is eval error for invalid or mismatch function arg
 	ErrInvalidArg = errors.New("invalid function arg")
+	//ErrInvalidInterval is an eval error returned when an interval is set to 0
+	ErrInvalidInterval = errors.New("invalid interval arg")
 )
 
 // NodeOrTag structure contains either Node (=integer) or Tag (=string)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -242,7 +242,39 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 					r[i].From = start
 				}
 			}
+		case "smartSummarize":
+			if len(e.args) < 2 {
+				return nil
+			}
 
+			alignToInterval, err := e.GetStringNamedOrPosArgDefault("alignTo", 3, "")
+			if err != nil {
+				return nil
+			}
+
+			if alignToInterval != "" {
+				var alignTo string
+				if !IsDigit(alignToInterval[0]) {
+					alignTo = "1" + alignToInterval // Add a 1 before the alignTo interval, so that IntervalString properly parses it
+				} else {
+					alignTo = alignToInterval
+				}
+				interval, err := IntervalString(alignTo, 1)
+				if err != nil {
+					return nil
+				}
+				for i, _ := range r {
+					start := r[i].From
+					for _, v := range []int64{86400, 3600, 60} {
+						if int64(interval) >= v {
+							start -= start % v
+							break
+						}
+					}
+
+					r[i].From = start
+				}
+			}
 		}
 		return r
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -607,6 +607,29 @@ func TestMetrics(t *testing.T) {
 				},
 			},
 		},
+		{
+			"smartSummarize(metric1, '1h', 'sum', 'hours')",
+			&expr{
+				target: "smartSummarize",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1h", etype: EtString},
+					{valStr: "sum", etype: EtString},
+					{valStr: "hours", etype: EtString},
+				},
+				argString: "metric1, '1h', 'sum', 'hours'",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410343200,
+					Until:  1410346865,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.s, func(t *testing.T) {


### PR DESCRIPTION
This PR rewrites the smartSummarize function in order to correct two issues that were discovered (similar to the recent fix to hitcount, see #132).  

When the interval parameter was set to a value smaller than the fetched data's step between data points, it results were incorrect. The results were a copy of the data points for each series in the list.  For example:
smartSummarize(metric1,'6m','sum', 'minutes')
[]*types.MetricData{{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 6}, 600, 0)},} // 10m step

The result will be []float64{2, 4, 6}. Issuing the same query with the same data in Graphite-web yielded results of [2, 4, None, 6, None]. This is due to the interval being smaller than the step, and therefore some resulting values will be NaN.

Additionally, in Graphite-web's implement of smartSummarize,  the start time of the request is adjusted based on the  alignTo value, and the data is re-fetched. In CarbonAPI, the start time was adjusted, but data was not re-fetched.
Major changes in this PR:

The smartSummarize function was completely rewritten to match the behavior of Graphite web, as well as adding some optimizations in the algorithm. This helps address the issue with intervals smaller than the data's step, as well as fixes discrepancies in results that were occurring with CarbonAPI tests that were tested in Graphite web.
The Metrics() function in pkg/parser.go was updated to adjust the start time of a metric request with a target of smartSummarize, so that the start time reflects the alignTo parameter's value. This is intended to prevent needing to re-fetch the data during smartSummarize function execution as is done in Graphite web.

Additionally, more testcases were added, including ones that cover the situation where the specific interval is smaller than the fetched data's step, as well as test cases translated from Graphite web for smartSummarize. 