### PR TITLE
Fix setting of consolidationFunc in smartSummarize results

### DIFF
--- a/expr/functions/smartSummarize/function.go
+++ b/expr/functions/smartSummarize/function.go
@@ -94,7 +94,7 @@ func (f *smartSummarize) Do(ctx context.Context, e parser.Expr, from, until int6
 				StepTime:          bucketSize,
 				StartTime:         arg.StartTime,
 				StopTime:          arg.StopTime,
-				ConsolidationFunc: summarizeFunction,
+				ConsolidationFunc: arg.ConsolidationFunc,
 			},
 			Tags: helper.CopyTags(arg),
 		}


### PR DESCRIPTION
This PR fixes an issue in which  the consolidation function in the smartSummarize results were being set to the aggregation function passed into the smartSummarize function. The consolidation function is not set in Graphite web's version of smartSummarize, and during testing, we noticed that this was causing inaccurate results with some queries. Instead, the same consolidation function that the original series had should be used.