### PR TITLE
Fix summarize consolidation handling of series with only NaN values

### DIFF
--- a/expr/consolidations/consolidations.go
+++ b/expr/consolidations/consolidations.go
@@ -261,6 +261,10 @@ func SummarizeValues(f string, values []float64, XFilesFactor float32) float64 {
 		}
 	}
 
+	if total == 0 {
+		return math.NaN()
+	}
+
 	if float32(total)/float32(len(values)) < XFilesFactor {
 		return math.NaN()
 	}

--- a/expr/consolidations/consolidations_test.go
+++ b/expr/consolidations/consolidations_test.go
@@ -128,6 +128,20 @@ func TestSummarizeValues(t *testing.T) {
 			xFilesFactor: 0,
 			expected:     3,
 		},
+		{
+			name:         "Only NaN",
+			function:     "sum",
+			values:       []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN()},
+			xFilesFactor: 0,
+			expected:     math.NaN(),
+		},
+		{
+			name:         "Only 0",
+			function:     "sum",
+			values:       []float64{0, 0, 0, 0, 0},
+			xFilesFactor: 0,
+			expected:     0,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR introduces a small fix for consolidations.SummarizeValues. If all the values passed into SummarizeValues are NaN, then the function should return a value of NaN, instead if 0.