### PR TITLE
Summarize function: Only adjust end time based on last ts in bucket if alignToFrom is set

### DIFF
--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -138,7 +138,9 @@ func (f *summarize) Do(ctx context.Context, e parser.Expr, from, until int64, va
 			r.Values = append(r.Values, rv)
 			ts = bucketUpperBound
 		}
-		r.StopTime = ts
+		if alignToFrom {
+			r.StopTime = ts
+		}
 		results[n] = &r
 	}
 


### PR DESCRIPTION
This PR adds a small fix to the summarize function in order to match behavior in Graphite web. The stop time of the results should only be adjusted to the timestamp of upper limit of the last bucket when alignToFrom is set to true. Otherwise, the new end calculated for cases when alignToFrom is set to false should be used as the stop time for the results.