### PR TITLE
Refactor expr.go

### DIFF
--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -290,6 +290,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 		ApiMetrics.BackendCacheMisses.Add(1)
 
 		results = make([]*types.MetricData, 0)
+		values := make(map[parser.MetricRequest][]*types.MetricData)
 
 		if config.Config.CombineMultipleTargetsInOne && len(targets) > 0 {
 			exprs := make([]parser.Expr, 0, len(targets))
@@ -306,7 +307,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 
 			ApiMetrics.RenderRequests.Add(1)
 
-			result, errs := expr.FetchAndEvalExprs(ctx, exprs, from32, until32)
+			result, errs := expr.FetchAndEvalExprs(ctx, exprs, from32, until32, values)
 			if errs != nil {
 				errors = errs
 			}
@@ -324,7 +325,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 
 				ApiMetrics.RenderRequests.Add(1)
 
-				result, err := expr.FetchAndEvalExp(ctx, exp, from32, until32)
+				result, err := expr.FetchAndEvalExp(ctx, exp, from32, until32, values)
 				if err != nil {
 					errors[target] = merry.Wrap(err)
 				}

--- a/cmd/carbonapi/http/render_handler.go
+++ b/cmd/carbonapi/http/render_handler.go
@@ -290,7 +290,6 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 		ApiMetrics.BackendCacheMisses.Add(1)
 
 		results = make([]*types.MetricData, 0)
-		values := make(map[parser.MetricRequest][]*types.MetricData)
 
 		if config.Config.CombineMultipleTargetsInOne && len(targets) > 0 {
 			exprs := make([]parser.Expr, 0, len(targets))
@@ -307,7 +306,7 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 
 			ApiMetrics.RenderRequests.Add(1)
 
-			result, errs := expr.FetchAndEvalExprs(ctx, exprs, from32, until32, values)
+			result, errs := expr.FetchAndEvalExprs(ctx, exprs, from32, until32)
 			if errs != nil {
 				errors = errs
 			}
@@ -325,17 +324,13 @@ func renderHandler(w http.ResponseWriter, r *http.Request) {
 
 				ApiMetrics.RenderRequests.Add(1)
 
-				result, err := expr.FetchAndEvalExp(ctx, exp, from32, until32, values)
+				result, err := expr.FetchAndEvalExp(ctx, exp, from32, until32)
 				if err != nil {
 					errors[target] = merry.Wrap(err)
 				}
 
 				results = append(results, result...)
 			}
-		}
-
-		for mFetch := range values {
-			expr.SortMetrics(values[mFetch], mFetch)
 		}
 
 		if len(errors) == 0 && backendCacheTimeout > 0 {

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -17,9 +17,7 @@ import (
 
 type evaluator struct{}
 
-// FetchAndEvalExprs fetch data and evaluates multiple expressions
-func (eval evaluator) FetchAndEvalExprs(ctx context.Context, exprs []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, map[string]merry.Error) {
-	var errors map[string]merry.Error
+func (eval evaluator) Fetch(ctx context.Context, exprs []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) error {
 	config.Config.Limiter.Enter()
 	defer config.Config.Limiter.Leave()
 
@@ -77,7 +75,7 @@ func (eval evaluator) FetchAndEvalExprs(ctx context.Context, exprs []parser.Expr
 		metrics, _, err := config.Config.ZipperInstance.Render(ctx, multiFetchRequest)
 		// If we had only partial result, we want to do our best to actually do our job
 		if err != nil && merry.HTTPCode(err) >= 400 && !haveFallbackSeries {
-			return nil, map[string]merry.Error{"*": merry.Wrap(err)}
+			return err
 		}
 		for _, metric := range metrics {
 			metricRequest := metricRequestCache[metric.PathExpression]
@@ -101,100 +99,10 @@ func (eval evaluator) FetchAndEvalExprs(ctx context.Context, exprs []parser.Expr
 		targetValues = helper.ScaleValuesToCommonStep(targetValues)
 	}
 
-	res := make([]*types.MetricData, 0, len(exprs))
-	for _, exp := range exprs {
-		evaluationResult, err := eval.Eval(ctx, exp, from, until, targetValues)
-		if err != nil {
-			if errors == nil {
-				errors = make(map[string]merry.Error)
-			}
-			errors[exp.Target()] = merry.Wrap(err)
-		}
-		res = append(res, evaluationResult...)
-	}
-	return res, errors
+	return nil
 }
 
-// FetchAndEvalExp fetch data and evalualtes expressions
-func (eval evaluator) FetchAndEvalExp(ctx context.Context, exp parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	config.Config.Limiter.Enter()
-	defer config.Config.Limiter.Leave()
-
-	multiFetchRequest := pb.MultiFetchRequest{}
-	metricRequestCache := make(map[string]parser.MetricRequest)
-	maxDataPoints := utilctx.GetMaxDatapoints(ctx)
-	// values related to this particular `target=`
-	targetValues := make(map[parser.MetricRequest][]*types.MetricData)
-
-	for _, m := range exp.Metrics(from, until) {
-		fetchRequest := pb.FetchRequest{
-			Name:           m.Metric,
-			PathExpression: m.Metric,
-			StartTime:      m.From,
-			StopTime:       m.Until,
-			MaxDataPoints:  maxDataPoints,
-		}
-		metricRequest := parser.MetricRequest{
-			Metric: fetchRequest.PathExpression,
-			From:   fetchRequest.StartTime,
-			Until:  fetchRequest.StopTime,
-		}
-
-		// avoid multiple requests in a function, E.g divideSeries(a.b, a.b)
-		if cachedMetricRequest, ok := metricRequestCache[m.Metric]; ok &&
-			cachedMetricRequest.From == metricRequest.From &&
-			cachedMetricRequest.Until == metricRequest.Until {
-			continue
-		}
-
-		// avoid multiple requests in a http request, E.g render?target=a.b&target=a.b
-		if _, ok := values[metricRequest]; ok {
-			targetValues[metricRequest] = nil
-			continue
-		}
-
-		// avoid multiple requests from the same target, e.g. target=max(a,asPercent(holtWintersForecast(a),a))
-		if _, ok := targetValues[metricRequest]; ok {
-			continue
-		}
-
-		metricRequestCache[m.Metric] = metricRequest
-		targetValues[metricRequest] = nil
-		multiFetchRequest.Metrics = append(multiFetchRequest.Metrics, fetchRequest)
-	}
-
-	if len(multiFetchRequest.Metrics) > 0 {
-		metrics, _, err := config.Config.ZipperInstance.Render(ctx, multiFetchRequest)
-		// If we had only partial result, we want to do our best to actually do our job
-		if err != nil && merry.HTTPCode(err) >= 400 && exp.Target() != "fallbackSeries" {
-			return nil, err
-		}
-		for _, metric := range metrics {
-			metricRequest := metricRequestCache[metric.PathExpression]
-			if metric.RequestStartTime != 0 && metric.RequestStopTime != 0 {
-				metricRequest.From = metric.RequestStartTime
-				metricRequest.Until = metric.RequestStopTime
-			}
-			data, ok := values[metricRequest]
-			if !ok {
-				data = make([]*types.MetricData, 0, 1)
-			}
-			values[metricRequest] = append(data, metric)
-		}
-	}
-
-	for m := range targetValues {
-		targetValues[m] = values[m]
-	}
-
-	if config.Config.ZipperInstance.ScaleToCommonStep() {
-		targetValues = helper.ScaleValuesToCommonStep(targetValues)
-	}
-
-	return eval.Eval(ctx, exp, from, until, targetValues)
-}
-
-// Eval evalualtes expressions
+// Eval evaluates expressions.
 func (eval evaluator) Eval(ctx context.Context, exp parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (results []*types.MetricData, err error) {
 	rewritten, targets, err := RewriteExpr(ctx, exp, from, until, values)
 	if err != nil {
@@ -206,7 +114,11 @@ func (eval evaluator) Eval(ctx context.Context, exp parser.Expr, from, until int
 			if err != nil {
 				return nil, err
 			}
-			result, err := eval.FetchAndEvalExp(ctx, exp, from, until, values)
+			err = eval.Fetch(ctx, []parser.Expr{exp}, from, until, values)
+			if err != nil {
+				return nil, err
+			}
+			result, err := eval.Eval(ctx, exp, from, until, values)
 			if err != nil {
 				return nil, err
 			}
@@ -224,16 +136,54 @@ func init() {
 	metadata.SetEvaluator(_evaluator)
 }
 
-// FetchAndEvalExp fetch data and evalualtes expressions
-func FetchAndEvalExp(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	return _evaluator.FetchAndEvalExp(ctx, e, from, until, values)
+// FetchAndEvalExp fetch data and evaluates expressions
+func FetchAndEvalExp(ctx context.Context, e parser.Expr, from, until int64) ([]*types.MetricData, merry.Error) {
+	values := make(map[parser.MetricRequest][]*types.MetricData)
+	err := _evaluator.Fetch(ctx, []parser.Expr{e}, from, until, values)
+	if err != nil {
+		return nil, merry.Wrap(err)
+	}
+
+	res, err := _evaluator.Eval(ctx, e, from, until, values)
+	if err != nil {
+		return nil, merry.Wrap(err)
+	}
+
+	for mReq := range values {
+		SortMetrics(values[mReq], mReq)
+	}
+
+	return res, nil
 }
 
-func FetchAndEvalExprs(ctx context.Context, exprs []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, map[string]merry.Error) {
-	return _evaluator.FetchAndEvalExprs(ctx, exprs, from, until, values)
+func FetchAndEvalExprs(ctx context.Context, exprs []parser.Expr, from, until int64) ([]*types.MetricData, map[string]merry.Error) {
+	values := make(map[parser.MetricRequest][]*types.MetricData)
+	err := _evaluator.Fetch(ctx, exprs, from, until, values)
+	if err != nil {
+		return nil, map[string]merry.Error{"*": merry.Wrap(err)}
+	}
+
+	res := make([]*types.MetricData, 0, len(exprs))
+	var errors map[string]merry.Error
+	for _, exp := range exprs {
+		evaluationResult, err := _evaluator.Eval(ctx, exp, from, until, values)
+		if err != nil {
+			if errors == nil {
+				errors = make(map[string]merry.Error)
+			}
+			errors[exp.Target()] = merry.Wrap(err)
+		}
+		res = append(res, evaluationResult...)
+	}
+
+	for mReq := range values {
+		SortMetrics(values[mReq], mReq)
+	}
+
+	return res, errors
 }
 
-// Eval is the main expression evaluator
+// EvalExpr is the main expression evaluator.
 func EvalExpr(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	if e.IsName() {
 		return values[parser.MetricRequest{Metric: e.Target(), From: from, Until: until}], nil

--- a/expr/interfaces/inteface.go
+++ b/expr/interfaces/inteface.go
@@ -27,7 +27,7 @@ type Evaluator interface {
 	// Fetch populates the values map being passed into it by translating input expressions into a series of
 	// parser.MetricRequest and fetching the raw data from the configured backend.
 	//
-	// It returns a map of only the data fetched in the current invocation.
+	// It returns a map of only the data requested in the current invocation, scaled to a common step.
 	Fetch(ctx context.Context, e []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (map[parser.MetricRequest][]*types.MetricData, error)
 	// Eval uses the raw data within the values map being passed into it to in order to evaluate the input expression.
 	Eval(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)

--- a/expr/interfaces/inteface.go
+++ b/expr/interfaces/inteface.go
@@ -22,8 +22,12 @@ func (b *FunctionBase) GetEvaluator() Evaluator {
 	return b.Evaluator
 }
 
-// Evaluator is a interface for any existing expression parser
+// Evaluator is an interface for any existing expression parser.
 type Evaluator interface {
+	// Fetch populates the values map being passed into it by translating input expressions into a series of
+	// parser.MetricRequest structs and fetching the raw data from the configured backend.
+	Fetch(ctx context.Context, e []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) error
+	// Eval uses the raw data within the values map being passed into it to in order to evaluate the input expression.
 	Eval(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
 }
 

--- a/expr/interfaces/inteface.go
+++ b/expr/interfaces/inteface.go
@@ -25,8 +25,10 @@ func (b *FunctionBase) GetEvaluator() Evaluator {
 // Evaluator is an interface for any existing expression parser.
 type Evaluator interface {
 	// Fetch populates the values map being passed into it by translating input expressions into a series of
-	// parser.MetricRequest structs and fetching the raw data from the configured backend.
-	Fetch(ctx context.Context, e []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) error
+	// parser.MetricRequest and fetching the raw data from the configured backend.
+	//
+	// It returns a map of only the data fetched in the current invocation.
+	Fetch(ctx context.Context, e []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (map[parser.MetricRequest][]*types.MetricData, error)
 	// Eval uses the raw data within the values map being passed into it to in order to evaluate the input expression.
 	Eval(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
 }

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -8,21 +8,22 @@ import (
 	"time"
 
 	"github.com/ansel1/merry"
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/metadata"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
 	"github.com/go-graphite/carbonapi/tests/compare"
-	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 )
 
 type FuncEvaluator struct {
 	eval func(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
 }
 
-func (evaluator *FuncEvaluator) Fetch(_ context.Context, _ []parser.Expr, _, _ int64, _ map[parser.MetricRequest][]*types.MetricData) error {
-	return nil
+func (evaluator *FuncEvaluator) Fetch(_ context.Context, _ []parser.Expr, _, _ int64, _ map[parser.MetricRequest][]*types.MetricData) (map[parser.MetricRequest][]*types.MetricData, error) {
+	return nil, nil
 }
 
 func (evaluator *FuncEvaluator) Eval(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -21,6 +21,10 @@ type FuncEvaluator struct {
 	eval func(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
 }
 
+func (evaluator *FuncEvaluator) Fetch(_ context.Context, _ []parser.Expr, _, _ int64, _ map[parser.MetricRequest][]*types.MetricData) error {
+	return nil
+}
+
 func (evaluator *FuncEvaluator) Eval(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	if e.IsName() {
 		return values[parser.MetricRequest{Metric: e.Target(), From: from, Until: until}], nil


### PR DESCRIPTION
This PR changes the interface of `interfaces.Evaluator` from this:
```
type Evaluator interface {
	Eval(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
}
```

to this:
```
type Evaluator interface {
        // Fetch populates the values map being passed into it by translating input expressions into a series of
	// parser.MetricRequest and fetching the raw data from the configured backend.
	//
	// It returns a map of only the data fetched in the current invocation.
	Fetch(ctx context.Context, e []parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) (map[parser.MetricRequest][]*types.MetricData, error)
	// Eval uses the raw data within the values map being passed into it to in order to evaluate the input expression.
	Eval(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error)
}
```

This decouples the fetching of raw data from the evaluation of expressions and allows implementations of `interface.Evaluator` to implement fetching from alternate backends with greater flexibility.