### PR TITLE
Use specified bootstrapInterval to adjust start time in holtWinters* functions

### DIFF
--- a/expr/functions/holtWintersForecast/function.go
+++ b/expr/functions/holtWintersForecast/function.go
@@ -35,7 +35,7 @@ func (f *holtWintersForecast) Do(ctx context.Context, e parser.Expr, from, until
 		return nil, err
 	}
 
-	args, err := helper.GetSeriesArgsAndRemoveNonExisting(ctx, e, from-bootstrapInterval, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from-bootstrapInterval, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -196,7 +196,7 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 			}
 
 			return r2
-		case "holtWintersForecast", "holtWintersConfidenceBands", "holtWintersAberration":
+		case "holtWintersForecast", "holtWintersConfidenceBands", "holtWintersConfidenceArea", "holtWintersAberration":
 			bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, 7*86400)
 			if err != nil {
 				return nil

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -197,8 +197,13 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 
 			return r2
 		case "holtWintersForecast", "holtWintersConfidenceBands", "holtWintersAberration":
+			bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, 7*86400)
+			if err != nil {
+				return nil
+			}
+
 			for i := range r {
-				r[i].From -= 7 * 86400 // starts -7 days from where the original starts
+				r[i].From -= bootstrapInterval
 			}
 		case "movingAverage", "movingMedian", "movingMin", "movingMax", "movingSum", "exponentialMovingAverage":
 			if len(e.args) < 2 {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -726,6 +726,72 @@ func TestMetrics(t *testing.T) {
 			},
 		},
 		{
+			"holtWintersConfidenceBands(metric1)",
+			&expr{
+				target: "holtWintersConfidenceBands",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+				},
+				argString: "metric1, 4, '1d'",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1409741940,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
+			"holtWintersConfidenceBands(metric1, 4, '1d')",
+			&expr{
+				target: "holtWintersConfidenceBands",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "4", etype: EtConst},
+					{valStr: "1d", etype: EtString},
+				},
+				argString: "metric1, 4, '1d'",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410260340,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
+			"holtWintersConfidenceBands(metric1, 4, bootstrapInterval='3d')",
+			&expr{
+				target: "holtWintersConfidenceBands",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "4", etype: EtConst},
+				},
+				namedArgs: map[string]*expr{
+					"bootstrapInterval": {etype: EtString, valStr: "3d"},
+				},
+				argString: "metric1, 4, '3d'",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410087540,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
 			"smartSummarize(metric1, '1h', 'sum', 'seconds')",
 			&expr{
 				target: "smartSummarize",


### PR DESCRIPTION
This PR fixes an issue that was found with the holtWinters* functions. Previously, the code was adjusting the start time of these functions by 7 days, which is the default value for the bootstrapInterval parameter. However, if a different bootstrapInterval was specified, when the series was retrieved via GetSeriesArg, the from value in the request was altered by subtracting the bootstrapInterval, and the previously fetched data was not matching the request due to the altered start time. Thus, nil results were being returned. This PR fixes this by factoring in the specified bootstrapInterval when adjusting the start time for holtWinters* Functions, and only using the default of 7d if no bootstrapInterval is specified in the query.