### PR TITLE
Return Nan result in moving* functions when a window's data consists of only NaN values

### DIFF
--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -180,7 +180,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		w := &types.Windowed{Data: make([]float64, windowSize)}
 		for i, v := range a.Values {
 			if ridx := i - offset; ridx >= 0 {
-				if helper.XFilesFactorValues(w.Data, xFilesFactor) {
+				if w.IsNonNull() && helper.XFilesFactorValues(w.Data, xFilesFactor) {
 					switch cons {
 					case "average":
 						r.Values[ridx] = w.Mean()

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -136,6 +136,8 @@ func TestMoving(t *testing.T) {
 		{
 			"movingAverage(metric1,'3sec')", // Check that a window that consists only of NaN points returns a value of math.NaN()
 			map[parser.MetricRequest][]*types.MetricData{
+				// These values introduce numerical errors in the sum, making it non-zero when it should be. 
+				// This causes a `0.0000...01/0` division, that results in infinity
 				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1e20, 0.e-20, 1, math.NaN(), math.NaN(), math.NaN(), 1, 1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, 1, 0}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,'3sec')`,

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -133,6 +133,14 @@ func TestMoving(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("movingMax(metric1,2)",
 				[]float64{math.NaN(), math.NaN(), 2, 3, 3, 2}, 1, 0).SetTag("movingMax", "2").SetNameTag("movingMax(metric1,2)")}, // StartTime = from
 		},
+		{
+			"movingAverage(metric1,'3sec')", // Check that a window that consists only of NaN points returns a value of math.NaN()
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", -3, 1}: {types.MakeMetricData("metric1", []float64{1e20, 0.e-20, 1, math.NaN(), math.NaN(), math.NaN(), 1, 1, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2, 1, 0}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(`movingAverage(metric1,'3sec')`,
+				[]float64{3.333333333333333e+19, 0, 0, math.NaN(), 0, 0.5, 0.5, 0, math.NaN(), math.NaN(), 1, 1}, 1, 0).SetTag("movingAverage", "'3sec'").SetNameTag(`movingAverage(metric1,'3sec')`)}, // StartTime = from
+		},
 	}
 
 	for n, tt := range tests {

--- a/expr/types/windowed.go
+++ b/expr/types/windowed.go
@@ -175,3 +175,12 @@ func (w *Windowed) Last() float64 {
 
 	return w.Data[w.head-1]
 }
+
+// IsNonNull checks if the window's data contains only NaN values
+// This is to prevent returning -Inf when the window's data contains only NaN values
+func (w *Windowed) IsNonNull() bool {
+	if len(w.Data) == w.nans {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
This PR fixes an issue that was observed when one of the moving* functions (movingWindow, movingAverage, etc) had a window that contained only NaN values. It was observed that the window's sum can become negative, and when Mean() was called on the window, the negative sum being divided by w.Len() (with a value of 0, since this function returns the result of subtracting the number of NaN values from the length of the window's data) resulted in -Inf being returned. Graphite-web checksif there are any non-null values, and if there are none, a value of None is returned for that window (see [here](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L1351) for implementation). This fix mimics this behavior in Graphite-web.