### PR TITLE
Fix descriptions for sin and exp

### DIFF
--- a/expr/functions/exp/function.go
+++ b/expr/functions/exp/function.go
@@ -56,7 +56,7 @@ func (f *exp) Do(ctx context.Context, e parser.Expr, from, until int64, values m
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
 func (f *exp) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
-		"add": {
+		"exp": {
 			Description: "Raise e to the power of the datapoint, where e = 2.718281… is the base of natural logarithms.\n\nExample:\n\n.. code-block:: none\n\n  &target=exp(Server.instance01.threads.busy)",
 			Function:    "exp(seriesList)",
 			Group:       "Transform",

--- a/expr/functions/sinFunction/function.go
+++ b/expr/functions/sinFunction/function.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"math"
 
+	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
+
 	"github.com/go-graphite/carbonapi/expr/interfaces"
 	"github.com/go-graphite/carbonapi/expr/types"
 	"github.com/go-graphite/carbonapi/pkg/parser"
-	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 )
 
 type sinFunction struct {
@@ -75,6 +76,35 @@ func (f *sinFunction) Do(ctx context.Context, e parser.Expr, from, until int64, 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
 func (f *sinFunction) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
+		"sin": {
+			Description: "Just returns the sine of the current time. The optional amplitude parameter changes the amplitude of the wave.\n" +
+				"Example:\n\n.. code-block:: none\n\n &target=sin(\"The.time.series\", 2)\n\n" +
+				"This would create a series named “The.time.series” that contains sin(x)*2. Accepts optional second argument as ‘amplitude’ parameter (default amplitude is 1)\n Accepts optional third argument as ‘step’ parameter (default step is 60 sec)\n\n" +
+				"Alias: sin",
+			Function: "sinFunction(name, amplitude=1, step=60)",
+			Group:    "Transform",
+			Module:   "graphite.render.functions",
+			Name:     "scale",
+			Params: []types.FunctionParam{
+				{
+					Name:     "name",
+					Required: true,
+					Type:     types.String,
+				},
+				{
+					Name:     "amplitude",
+					Required: false,
+					Type:     types.Integer,
+					Default:  types.NewSuggestion(1),
+				},
+				{
+					Name:     "step",
+					Required: false,
+					Type:     types.Integer,
+					Default:  types.NewSuggestion(60),
+				},
+			},
+		},
 		"sinFunction": {
 			Description: "Just returns the sine of the current time. The optional amplitude parameter changes the amplitude of the wave.\n" +
 				"Example:\n\n.. code-block:: none\n\n &target=sin(\"The.time.series\", 2)\n\n" +


### PR DESCRIPTION
sin - this was added to function metadata but was missing from Description()

exp - description name was set to "add" instead of "exp"