### PR TITLE
Add support for 'seasonality' parameter in holtWinters* functions

### DIFF
--- a/expr/functions/holtWintersAberration/function.go
+++ b/expr/functions/holtWintersAberration/function.go
@@ -46,6 +46,11 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 		return nil, err
 	}
 
+	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 3, 1, 86400)
+	if err != nil {
+		return nil, err
+	}
+
 	results := make([]*types.MetricData, 0, len(args))
 	for _, arg := range args {
 		var (
@@ -55,7 +60,7 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 
 		stepTime := arg.StepTime
 
-		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(arg.Values, stepTime, delta, bootstrapInterval/86400)
+		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(arg.Values, stepTime, delta, bootstrapInterval, seasonality)
 
 		windowPoints := int(bootstrapInterval / stepTime)
 		if len(arg.Values) > windowPoints {

--- a/expr/functions/holtWintersAberration/function.go
+++ b/expr/functions/holtWintersAberration/function.go
@@ -31,7 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, 7*86400)
+	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, holtwinters.DefaultBootstrapInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 		return nil, err
 	}
 
-	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 3, 1, 86400)
+	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 3, 1, holtwinters.DefaultSeasonality)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/holtWintersConfidenceArea/function_cairo.go
+++ b/expr/functions/holtWintersConfidenceArea/function_cairo.go
@@ -34,7 +34,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *holtWintersConfidenceArea) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, 7*86400)
+	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, holtwinters.DefaultBootstrapInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (f *holtWintersConfidenceArea) Do(ctx context.Context, e parser.Expr, from,
 		return nil, err
 	}
 
-	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 3, 1, 86400)
+	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 3, 1, holtwinters.DefaultSeasonality)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/holtWintersConfidenceArea/function_cairo.go
+++ b/expr/functions/holtWintersConfidenceArea/function_cairo.go
@@ -49,22 +49,27 @@ func (f *holtWintersConfidenceArea) Do(ctx context.Context, e parser.Expr, from,
 		return nil, err
 	}
 
+	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 3, 1, 86400)
+	if err != nil {
+		return nil, err
+	}
+
 	results := make([]*types.MetricData, 0, len(args)*2)
 	for _, arg := range args {
 		stepTime := arg.StepTime
 
-		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(arg.Values, stepTime, delta, bootstrapInterval/86400)
+		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(arg.Values, stepTime, delta, bootstrapInterval, seasonality)
 
 		lowerSeries := types.MetricData{
 			FetchResponse: pb.FetchResponse{
-				Name:              fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
+				Name:              fmt.Sprintf("holtWintersConfidenceArea(%s)", arg.Name),
 				Values:            lowerBand,
 				StepTime:          arg.StepTime,
 				StartTime:         arg.StartTime + bootstrapInterval,
 				StopTime:          arg.StopTime,
 				ConsolidationFunc: arg.ConsolidationFunc,
 				XFilesFactor:      arg.XFilesFactor,
-				PathExpression:    fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
+				PathExpression:    fmt.Sprintf("holtWintersConfidenceArea(%s)", arg.Name),
 			},
 			Tags: helper.CopyTags(arg),
 			GraphOptions: types.GraphOptions{
@@ -77,14 +82,14 @@ func (f *holtWintersConfidenceArea) Do(ctx context.Context, e parser.Expr, from,
 
 		upperSeries := types.MetricData{
 			FetchResponse: pb.FetchResponse{
-				Name:              fmt.Sprintf("holtWintersConfidenceUpper(%s)", arg.Name),
+				Name:              fmt.Sprintf("holtWintersConfidenceArea(%s)", arg.Name),
 				Values:            upperBand,
 				StepTime:          arg.StepTime,
 				StartTime:         arg.StartTime + bootstrapInterval,
 				StopTime:          arg.StopTime,
 				ConsolidationFunc: arg.ConsolidationFunc,
 				XFilesFactor:      arg.XFilesFactor,
-				PathExpression:    fmt.Sprintf("holtWintersConfidenceLower(%s)", arg.Name),
+				PathExpression:    fmt.Sprintf("holtWintersConfidenceArea(%s)", arg.Name),
 			},
 			Tags: helper.CopyTags(arg),
 			GraphOptions: types.GraphOptions{

--- a/expr/functions/holtWintersConfidenceArea/function_test.go
+++ b/expr/functions/holtWintersConfidenceArea/function_test.go
@@ -4,6 +4,7 @@
 package holtWintersConfidenceArea
 
 import (
+	"github.com/go-graphite/carbonapi/expr/holtwinters"
 	"testing"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -27,14 +28,12 @@ func TestHoltWintersConfidenceArea(t *testing.T) {
 	var startTime int64 = 2678400
 	var step int64 = 600
 	var points int64 = 10
-	var weekSeconds int64 = 7 * 86400
-	var seconds int64 = 86400
 
 	tests := []th.EvalTestItemWithRange{
 		{
 			Target: "holtWintersConfidenceArea(metric1)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - weekSeconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((weekSeconds/step)+points)*step, step), step, startTime-weekSeconds)},
+				{"metric1", startTime - holtwinters.DefaultBootstrapInterval, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step), step, startTime-holtwinters.DefaultBootstrapInterval)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{0.2841206166091448, 1.0581027098774411, 0.3338172102994683, 0.5116859493263242, -0.18199175514936972, 0.2366173792019426, -1.2941554508809152, -0.513426806531049, -0.7970905542723132, 0.09868900726536012}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
@@ -46,7 +45,7 @@ func TestHoltWintersConfidenceArea(t *testing.T) {
 		{
 			Target: "holtWintersConfidenceArea(metric1,4,'6d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - 6*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*seconds/step)+points)*step, step), step, startTime-6*seconds)},
+				{"metric1", startTime - 6*holtwinters.SecondsPerDay, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-6*holtwinters.SecondsPerDay)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{-0.6535362793382391, -0.26554972418633316, -1.1060549683277792, -0.5788026852576289, -1.4594446935142829, -0.6933311085203409, -1.6566119269969288, -1.251651025511391, -1.7938581852717226, -1.1791817117029604}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
@@ -58,7 +57,7 @@ func TestHoltWintersConfidenceArea(t *testing.T) {
 		{
 			Target: "holtWintersConfidenceArea(metric1,4,'1d','2d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((seconds/step)+points)*step, step), step, startTime-seconds)},
+				{"metric1", startTime - holtwinters.SecondsPerDay, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-holtwinters.SecondsPerDay)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{4.106587168490873, 3.8357974803355406, 3.564589629688576, 3.421354957735917, 3.393696278743315, 3.470415673952413, 3.2748850646377368, 3.3539750816574316, 3.5243322056965765, 3.7771201010598134}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),

--- a/expr/functions/holtWintersConfidenceArea/function_test.go
+++ b/expr/functions/holtWintersConfidenceArea/function_test.go
@@ -28,18 +28,41 @@ func TestHoltWintersConfidenceArea(t *testing.T) {
 	var step int64 = 600
 	var points int64 = 10
 	var weekSeconds int64 = 7 * 86400
-
-	seriesValues := generateHwRange(0, ((weekSeconds/step)+points)*step, step)
+	var seconds int64 = 86400
 
 	tests := []th.EvalTestItemWithRange{
 		{
 			Target: "holtWintersConfidenceArea(metric1)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - weekSeconds, startTime + step*points}: {types.MakeMetricData("metric1", seriesValues, step, startTime-weekSeconds)},
+				{"metric1", startTime - weekSeconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((weekSeconds/step)+points)*step, step), step, startTime-weekSeconds)},
 			},
 			Want: []*types.MetricData{
-				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{0.2841206166091448, 1.0581027098774411, 0.3338172102994683, 0.5116859493263242, -0.18199175514936972, 0.2366173792019426, -1.2941554508809152, -0.513426806531049, -0.7970905542723132, 0.09868900726536012}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
-				types.MakeMetricData("holtWintersConfidenceUpper(metric1)", []float64{8.424944558327624, 9.409422251880809, 10.607070189221787, 10.288439865038768, 9.491556863132963, 9.474595784593738, 8.572310478053845, 8.897670449095346, 8.941566968508148, 9.409728797779282}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
+				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{0.2841206166091448, 1.0581027098774411, 0.3338172102994683, 0.5116859493263242, -0.18199175514936972, 0.2366173792019426, -1.2941554508809152, -0.513426806531049, -0.7970905542723132, 0.09868900726536012}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
+				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{8.424944558327624, 9.409422251880809, 10.607070189221787, 10.288439865038768, 9.491556863132963, 9.474595784593738, 8.572310478053845, 8.897670449095346, 8.941566968508148, 9.409728797779282}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+		{
+			Target: "holtWintersConfidenceArea(metric1,4,'6d')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", startTime - 6*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*seconds/step)+points)*step, step), step, startTime-6*seconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{-0.6535362793382391, -0.26554972418633316, -1.1060549683277792, -0.5788026852576289, -1.4594446935142829, -0.6933311085203409, -1.6566119269969288, -1.251651025511391, -1.7938581852717226, -1.1791817117029604}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
+				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{8.166528156512886, 8.759008839563066, 9.250962452510654, 9.994110161265208, 10.511931730022393, 11.34313475259535, 12.639554646464758, 11.972601342482212, 10.920216551100442, 10.618692557967133}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+		{
+			Target: "holtWintersConfidenceArea(metric1,4,'1d','2d')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((seconds/step)+points)*step, step), step, startTime-seconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{4.106587168490873, 3.8357974803355406, 3.564589629688576, 3.421354957735917, 3.393696278743315, 3.470415673952413, 3.2748850646377368, 3.3539750816574316, 3.5243322056965765, 3.7771201010598134}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
+				types.MakeMetricData("holtWintersConfidenceArea(metric1)", []float64{4.24870339314537, 4.501056063000946, 4.956252698437961, 5.466294981886822, 6.0258698337471355, 6.630178145979606, 7.6413984841547204, 6.492608523867341, 5.556775146625346, 4.813280235806231}, step, startTime).SetTag("holtWintersConfidenceArea", "1"),
 			},
 			From:  startTime,
 			Until: startTime + step*points,

--- a/expr/functions/holtWintersConfidenceBands/function.go
+++ b/expr/functions/holtWintersConfidenceBands/function.go
@@ -2,7 +2,6 @@ package holtWintersConfidenceBands
 
 import (
 	"context"
-
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/holtwinters"
 	"github.com/go-graphite/carbonapi/expr/interfaces"
@@ -45,11 +44,16 @@ func (f *holtWintersConfidenceBands) Do(ctx context.Context, e parser.Expr, from
 		return nil, err
 	}
 
+	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 3, 1, 86400)
+	if err != nil {
+		return nil, err
+	}
+
 	results := make([]*types.MetricData, 0, len(args)*2)
 	for _, arg := range args {
 		stepTime := arg.StepTime
 
-		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(arg.Values, stepTime, delta, bootstrapInterval/86400)
+		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(arg.Values, stepTime, delta, bootstrapInterval, seasonality)
 
 		name := "holtWintersConfidenceLower(" + arg.Name + ")"
 		lowerSeries := &types.MetricData{

--- a/expr/functions/holtWintersConfidenceBands/function.go
+++ b/expr/functions/holtWintersConfidenceBands/function.go
@@ -29,7 +29,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *holtWintersConfidenceBands) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, 7*86400)
+	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, holtwinters.DefaultBootstrapInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (f *holtWintersConfidenceBands) Do(ctx context.Context, e parser.Expr, from
 		return nil, err
 	}
 
-	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 3, 1, 86400)
+	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 3, 1, holtwinters.DefaultSeasonality)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/holtWintersConfidenceBands/function_test.go
+++ b/expr/functions/holtWintersConfidenceBands/function_test.go
@@ -1,6 +1,7 @@
 package holtWintersConfidenceBands
 
 import (
+	"github.com/go-graphite/carbonapi/expr/holtwinters"
 	"testing"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -24,13 +25,12 @@ func TestHoltWintersConfidenceBands(t *testing.T) {
 	var startTime int64 = 2678400
 	var step int64 = 600
 	var points int64 = 10
-	var seconds int64 = 86400
 
 	tests := []th.EvalTestItemWithRange{
 		{
 			Target: "holtWintersConfidenceBands(metric1)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - 7*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, (((7*seconds)/step)+points)*step, step), step, startTime-(7*seconds))},
+				{"metric1", startTime - holtwinters.DefaultBootstrapInterval, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, (((holtwinters.DefaultBootstrapInterval)/step)+points)*step, step), step, startTime-(holtwinters.DefaultBootstrapInterval))},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{0.2841206166091448, 1.0581027098774411, 0.3338172102994683, 0.5116859493263242, -0.18199175514936972, 0.2366173792019426, -1.2941554508809152, -0.513426806531049, -0.7970905542723132, 0.09868900726536012}, step, startTime).SetTag("holtWintersConfidenceLower", "1"),
@@ -42,7 +42,7 @@ func TestHoltWintersConfidenceBands(t *testing.T) {
 		{
 			Target: "holtWintersConfidenceBands(metric1,4,'6d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - 6*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*seconds/step)+points)*step, step), step, startTime-6*seconds)},
+				{"metric1", startTime - 6*holtwinters.SecondsPerDay, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-6*holtwinters.SecondsPerDay)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{-0.6535362793382391, -0.26554972418633316, -1.1060549683277792, -0.5788026852576289, -1.4594446935142829, -0.6933311085203409, -1.6566119269969288, -1.251651025511391, -1.7938581852717226, -1.1791817117029604}, step, startTime).SetTag("holtWintersConfidenceLower", "1"),
@@ -54,7 +54,7 @@ func TestHoltWintersConfidenceBands(t *testing.T) {
 		{
 			Target: "holtWintersConfidenceBands(metric1,4,'1d','2d')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((seconds/step)+points)*step, step), step, startTime-seconds)},
+				{"metric1", startTime - holtwinters.SecondsPerDay, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.SecondsPerDay/step)+points)*step, step), step, startTime-holtwinters.SecondsPerDay)},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{4.106587168490873, 3.8357974803355406, 3.564589629688576, 3.421354957735917, 3.393696278743315, 3.470415673952413, 3.2748850646377368, 3.3539750816574316, 3.5243322056965765, 3.7771201010598134}, step, startTime).SetTag("holtWintersConfidenceLower", "1"),

--- a/expr/functions/holtWintersConfidenceBands/function_test.go
+++ b/expr/functions/holtWintersConfidenceBands/function_test.go
@@ -24,19 +24,41 @@ func TestHoltWintersConfidenceBands(t *testing.T) {
 	var startTime int64 = 2678400
 	var step int64 = 600
 	var points int64 = 10
-	var weekSeconds int64 = 7 * 86400
-
-	seriesValues := generateHwRange(0, ((weekSeconds/step)+points)*step, step)
+	var seconds int64 = 86400
 
 	tests := []th.EvalTestItemWithRange{
 		{
 			Target: "holtWintersConfidenceBands(metric1)",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", startTime - weekSeconds, startTime + step*points}: {types.MakeMetricData("metric1", seriesValues, step, startTime-weekSeconds)},
+				{"metric1", startTime - 7*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, (((7*seconds)/step)+points)*step, step), step, startTime-(7*seconds))},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{0.2841206166091448, 1.0581027098774411, 0.3338172102994683, 0.5116859493263242, -0.18199175514936972, 0.2366173792019426, -1.2941554508809152, -0.513426806531049, -0.7970905542723132, 0.09868900726536012}, step, startTime).SetTag("holtWintersConfidenceLower", "1"),
 				types.MakeMetricData("holtWintersConfidenceUpper(metric1)", []float64{8.424944558327624, 9.409422251880809, 10.607070189221787, 10.288439865038768, 9.491556863132963, 9.474595784593738, 8.572310478053845, 8.897670449095346, 8.941566968508148, 9.409728797779282}, step, startTime).SetTag("holtWintersConfidenceUpper", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+		{
+			Target: "holtWintersConfidenceBands(metric1,4,'6d')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", startTime - 6*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*seconds/step)+points)*step, step), step, startTime-6*seconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{-0.6535362793382391, -0.26554972418633316, -1.1060549683277792, -0.5788026852576289, -1.4594446935142829, -0.6933311085203409, -1.6566119269969288, -1.251651025511391, -1.7938581852717226, -1.1791817117029604}, step, startTime).SetTag("holtWintersConfidenceLower", "1"),
+				types.MakeMetricData("holtWintersConfidenceUpper(metric1)", []float64{8.166528156512886, 8.759008839563066, 9.250962452510654, 9.994110161265208, 10.511931730022393, 11.34313475259535, 12.639554646464758, 11.972601342482212, 10.920216551100442, 10.618692557967133}, step, startTime).SetTag("holtWintersConfidenceUpper", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+		{
+			Target: "holtWintersConfidenceBands(metric1,4,'1d','2d')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((seconds/step)+points)*step, step), step, startTime-seconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersConfidenceLower(metric1)", []float64{4.106587168490873, 3.8357974803355406, 3.564589629688576, 3.421354957735917, 3.393696278743315, 3.470415673952413, 3.2748850646377368, 3.3539750816574316, 3.5243322056965765, 3.7771201010598134}, step, startTime).SetTag("holtWintersConfidenceLower", "1"),
+				types.MakeMetricData("holtWintersConfidenceUpper(metric1)", []float64{4.24870339314537, 4.501056063000946, 4.956252698437961, 5.466294981886822, 6.0258698337471355, 6.630178145979606, 7.6413984841547204, 6.492608523867341, 5.556775146625346, 4.813280235806231}, step, startTime).SetTag("holtWintersConfidenceUpper", "1"),
 			},
 			From:  startTime,
 			Until: startTime + step*points,

--- a/expr/functions/holtWintersForecast/function.go
+++ b/expr/functions/holtWintersForecast/function.go
@@ -30,7 +30,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 func (f *holtWintersForecast) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
-	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 1, 1, 7*86400)
+	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 1, 1, holtwinters.DefaultBootstrapInterval)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (f *holtWintersForecast) Do(ctx context.Context, e parser.Expr, from, until
 		return nil, err
 	}
 
-	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 2, 1, 86400)
+	seasonality, err := e.GetIntervalNamedOrPosArgDefault("seasonality", 2, 1, holtwinters.DefaultSeasonality)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/holtwinters/hw.go
+++ b/expr/holtwinters/hw.go
@@ -27,15 +27,14 @@ func holtWintersDeviation(gamma, actual, prediction, lastSeasonalDev float64) fl
 }
 
 // HoltWintersAnalysis do Holt-Winters Analysis
-func HoltWintersAnalysis(series []float64, step int64) ([]float64, []float64) {
+func HoltWintersAnalysis(series []float64, step int64, seasonality int64) ([]float64, []float64) {
 	const (
 		alpha = 0.1
 		beta  = 0.0035
 		gamma = 0.1
 	)
 
-	// season is currently one day
-	seasonLength := 24 * 60 * 60 / int(step)
+	seasonLength := seasonality / step
 
 	// seasonLength needs to be at least 2, so we force it
 	// GraphiteWeb has the same problem, still needs fixing https://github.com/graphite-project/graphite-web/issues/2780
@@ -52,7 +51,7 @@ func HoltWintersAnalysis(series []float64, step int64) ([]float64, []float64) {
 	)
 
 	getLastSeasonal := func(i int) float64 {
-		j := i - seasonLength
+		j := i - int(seasonLength)
 		if j >= 0 {
 			return seasonals[j]
 		}
@@ -60,7 +59,7 @@ func HoltWintersAnalysis(series []float64, step int64) ([]float64, []float64) {
 	}
 
 	getLastDeviation := func(i int) float64 {
-		j := i - seasonLength
+		j := i - int(seasonLength)
 		if j >= 0 {
 			return deviations[j]
 		}
@@ -122,12 +121,12 @@ func HoltWintersAnalysis(series []float64, step int64) ([]float64, []float64) {
 }
 
 // HoltWintersConfidenceBands do Holt-Winters Confidence Bands
-func HoltWintersConfidenceBands(series []float64, step int64, delta float64, days int64) ([]float64, []float64) {
+func HoltWintersConfidenceBands(series []float64, step int64, delta float64, bootstrapInterval int64, seasonality int64) ([]float64, []float64) {
 	var lowerBand, upperBand []float64
 
-	predictions, deviations := HoltWintersAnalysis(series, step)
+	predictions, deviations := HoltWintersAnalysis(series, step, seasonality)
 
-	windowPoints := int(days * 86400 / step)
+	windowPoints := int(bootstrapInterval / step)
 
 	var (
 		predictionsOfInterest []float64

--- a/expr/holtwinters/hw.go
+++ b/expr/holtwinters/hw.go
@@ -7,6 +7,12 @@ import (
 	"math"
 )
 
+const (
+	DefaultSeasonality       = 86400  // Seconds in 1 day
+	DefaultBootstrapInterval = 604800 // Seconds in 7 days
+	SecondsPerDay            = 86400
+)
+
 func holtWintersIntercept(alpha, actual, lastSeason, lastIntercept, lastSlope float64) float64 {
 	return alpha*(actual-lastSeason) + (1-alpha)*(lastIntercept+lastSlope)
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"fmt"
+	"github.com/go-graphite/carbonapi/expr/holtwinters"
 	"regexp"
 	"strconv"
 	"strings"
@@ -197,7 +198,7 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 
 			return r2
 		case "holtWintersForecast", "holtWintersConfidenceBands", "holtWintersConfidenceArea", "holtWintersAberration":
-			bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, 7*86400)
+			bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, holtwinters.DefaultBootstrapInterval)
 			if err != nil {
 				return nil
 			}


### PR DESCRIPTION
This PR adds support for the optional 'seasonality' parameter in holtWinters* functions. Previously, none of the holtWinters* functions supported parsing this parameter from the query, and instead the default value of `1d` was used in calculations that factored in this parameter. With this change, the processing of the specified value of seasonality (or the default in case not specified) will be used in the holtWintersAnalysis helper function, providing more accurate results. 

See the [Graphite-web implementation](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L4002) where seasonality is used.
See also the [Graphite-web function descriptions](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.holtWintersAberration)  for full function definitions, descriptions and accepted parameters.