### PR TITLE
Fix holtWintersAberration fetching and processing of data

### DIFF
--- a/expr/functions/holtWintersAberration/function.go
+++ b/expr/functions/holtWintersAberration/function.go
@@ -36,7 +36,7 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 		return nil, err
 	}
 
-	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from-bootstrapInterval, until, values)
+	args, err := helper.GetSeriesArg(ctx, e.Arg(0), from, until, values)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/holtWintersAberration/function.go
+++ b/expr/functions/holtWintersAberration/function.go
@@ -55,25 +55,28 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 	for _, arg := range args {
 		var (
 			aberration []float64
-			series     []float64
 		)
 
 		stepTime := arg.StepTime
 
-		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(arg.Values, stepTime, delta, bootstrapInterval, seasonality)
-
-		windowPoints := int(bootstrapInterval / stepTime)
-		if len(arg.Values) > windowPoints {
-			series = arg.Values[windowPoints:]
+		// Note: additional fetch requests are added with an adjusted start time in expr.Metrics() (in
+		// pkg/parser/parser.go) so that the appropriate data corresponding to the adjusted start time
+		// can be pre-fetched.
+		adjustedExp := parser.NewTargetExpr(arg.Name)
+		seriesAdjustedStart, err := helper.GetSeriesArg(ctx, adjustedExp, from-bootstrapInterval, until, values)
+		if err != nil {
+			return nil, err
 		}
 
-		for i := range series {
-			if math.IsNaN(series[i]) {
+		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(seriesAdjustedStart[0].Values, stepTime, delta, bootstrapInterval, seasonality)
+
+		for i, v := range arg.Values {
+			if math.IsNaN(v) {
 				aberration = append(aberration, 0)
-			} else if !math.IsNaN(upperBand[i]) && series[i] > upperBand[i] {
-				aberration = append(aberration, series[i]-upperBand[i])
-			} else if !math.IsNaN(lowerBand[i]) && series[i] < lowerBand[i] {
-				aberration = append(aberration, series[i]-lowerBand[i])
+			} else if !math.IsNaN(upperBand[i]) && v > upperBand[i] {
+				aberration = append(aberration, v-upperBand[i])
+			} else if !math.IsNaN(lowerBand[i]) && v < lowerBand[i] {
+				aberration = append(aberration, v-lowerBand[i])
 			} else {
 				aberration = append(aberration, 0)
 			}
@@ -85,7 +88,7 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 				Name:              name,
 				Values:            aberration,
 				StepTime:          arg.StepTime,
-				StartTime:         arg.StartTime + bootstrapInterval,
+				StartTime:         arg.StartTime,
 				StopTime:          arg.StopTime,
 				PathExpression:    name,
 				ConsolidationFunc: arg.ConsolidationFunc,

--- a/expr/functions/holtWintersAberration/function_test.go
+++ b/expr/functions/holtWintersAberration/function_test.go
@@ -85,6 +85,26 @@ func TestHoltWintersAberration(t *testing.T) {
 			From:  startTime,
 			Until: startTime + step*points,
 		},
+		{
+			Target: "holtWintersAberration(metric*)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", startTime, startTime + step*points}: {
+					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
+					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
+				},
+				{"metric*", startTime - holtwinters.DefaultBootstrapInterval, startTime + step*points}: {
+					types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step, 0), step, startTime-holtwinters.DefaultBootstrapInterval),
+					types.MakeMetricData("metric2", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step, 10), step, startTime-holtwinters.DefaultBootstrapInterval),
+					types.MakeMetricData("metric3", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step, 20), step, startTime-holtwinters.DefaultBootstrapInterval), // Verify that metrics that don't match those fetched with the unadjusted start time are not included in the results
+				},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersAberration(metric1)", []float64{-0.2841206166091448, -0.05810270987744115, 0, 0, 0, 0, 0, 0, 0, 0}, step, startTime).SetTag("holtWintersAberration", "1"),
+				types.MakeMetricData("holtWintersAberration(metric2)", []float64{-0.284120616609151, -0.05810270987744737, 0, 0, 0, 0, 0, 0, 0, 0}, step, startTime).SetTag("holtWintersAberration", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/functions/holtWintersAberration/function_test.go
+++ b/expr/functions/holtWintersAberration/function_test.go
@@ -1,0 +1,99 @@
+package holtWintersAberration
+
+import (
+	"testing"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestHoltWintersAberration(t *testing.T) {
+	var startTime int64 = 2678400
+	var step int64 = 600
+	var points int64 = 10
+	var seconds int64 = 86400
+
+	tests := []th.EvalTestItemWithRange{
+		{
+			Target: "holtWintersAberration(metric*)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", startTime, startTime + step*points}: {
+					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
+					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
+				},
+				{"metric1", startTime - 7*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((7*seconds/step)+points)*step, step, 0), step, startTime-7*seconds)},
+				{"metric2", startTime - 7*seconds, startTime + step*points}: {types.MakeMetricData("metric2", generateHwRange(0, ((7*seconds/step)+points)*step, step, 10), step, startTime-7*seconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersAberration(metric1)", []float64{-0.2841206166091448, -0.05810270987744115, 0, 0, 0, 0, 0, 0, 0, 0}, step, startTime).SetTag("holtWintersAberration", "1"),
+				types.MakeMetricData("holtWintersAberration(metric2)", []float64{-0.284120616609151, -0.05810270987744737, 0, 0, 0, 0, 0, 0, 0, 0}, step, startTime).SetTag("holtWintersAberration", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+		{
+			Target: "holtWintersAberration(metric*,4,'4d')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", startTime, startTime + step*points}: {
+					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
+					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
+				},
+				{"metric1", startTime - 4*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*seconds/step)+points)*step, step, 0), step, startTime-4*seconds)},
+				{"metric2", startTime - 4*seconds, startTime + step*points}: {types.MakeMetricData("metric2", generateHwRange(0, ((6*seconds/step)+points)*step, step, 10), step, startTime-4*seconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersAberration(metric1)", []float64{-1.4410544085511923, -0.5199507849641569, 0, 0, 0, 0, 0, 0, 0, 0.09386319244056907}, step, startTime).SetTag("holtWintersAberration", "1"),
+				types.MakeMetricData("holtWintersAberration(metric2)", []float64{-1.4410544085511923, -0.5199507849641609, 0, 0, 0, 0, 0, 0, 0, 0.09386319244056551}, step, startTime).SetTag("holtWintersAberration", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+		{
+			Target: "holtWintersAberration(metric*,4,'1d','2d')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", startTime, startTime + step*points}: {
+					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
+					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
+				},
+				{"metric1", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, (((7*seconds)/step)+points)*step, step, 0), step, startTime-seconds)},
+				{"metric2", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric2", generateHwRange(0, (((7*seconds)/step)+points)*step, step, 10), step, startTime-seconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersAberration(metric1)", []float64{-4.106587168490873, -2.8357974803355406, -1.5645896296885762, -0.4213549577359168, 0, 0, 0, 0.5073914761326588, 2.4432248533746543, 4.186719764193769}, step, startTime).SetTag("holtWintersAberration", "1"),
+				types.MakeMetricData("holtWintersAberration(metric2)", []float64{-4.1065871684908775, -2.8357974803355486, -1.5645896296885837, -0.42135495773592346, 0, 0, 0, 0.5073914761326499, 2.4432248533746446, 4.186719764193759}, step, startTime).SetTag("holtWintersAberration", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
+		})
+	}
+}
+
+func generateHwRange(x, y, jump, t int64) []float64 {
+	var valuesList []float64
+	for x < y {
+		val := float64(t + (x/jump)%10)
+		valuesList = append(valuesList, val)
+		x += jump
+	}
+	return valuesList
+}

--- a/expr/functions/holtWintersAberration/function_test.go
+++ b/expr/functions/holtWintersAberration/function_test.go
@@ -1,6 +1,7 @@
 package holtWintersAberration
 
 import (
+	"github.com/go-graphite/carbonapi/expr/holtwinters"
 	"testing"
 
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -34,8 +35,10 @@ func TestHoltWintersAberration(t *testing.T) {
 					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
 					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
 				},
-				{"metric1", startTime - 7*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((7*seconds/step)+points)*step, step, 0), step, startTime-7*seconds)},
-				{"metric2", startTime - 7*seconds, startTime + step*points}: {types.MakeMetricData("metric2", generateHwRange(0, ((7*seconds/step)+points)*step, step, 10), step, startTime-7*seconds)},
+				{"metric*", startTime - holtwinters.DefaultBootstrapInterval, startTime + step*points}: {
+					types.MakeMetricData("metric1", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step, 0), step, startTime-holtwinters.DefaultBootstrapInterval),
+					types.MakeMetricData("metric2", generateHwRange(0, ((holtwinters.DefaultBootstrapInterval/step)+points)*step, step, 10), step, startTime-holtwinters.DefaultBootstrapInterval),
+				},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersAberration(metric1)", []float64{-0.2841206166091448, -0.05810270987744115, 0, 0, 0, 0, 0, 0, 0, 0}, step, startTime).SetTag("holtWintersAberration", "1"),
@@ -51,8 +54,10 @@ func TestHoltWintersAberration(t *testing.T) {
 					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
 					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
 				},
-				{"metric1", startTime - 4*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*seconds/step)+points)*step, step, 0), step, startTime-4*seconds)},
-				{"metric2", startTime - 4*seconds, startTime + step*points}: {types.MakeMetricData("metric2", generateHwRange(0, ((6*seconds/step)+points)*step, step, 10), step, startTime-4*seconds)},
+				{"metric*", startTime - 4*seconds, startTime + step*points}: {
+					types.MakeMetricData("metric1", generateHwRange(0, ((4*seconds/step)+points)*step, step, 0), step, startTime-4*seconds),
+					types.MakeMetricData("metric2", generateHwRange(0, ((4*seconds/step)+points)*step, step, 10), step, startTime-4*seconds),
+				},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersAberration(metric1)", []float64{-1.4410544085511923, -0.5199507849641569, 0, 0, 0, 0, 0, 0, 0, 0.09386319244056907}, step, startTime).SetTag("holtWintersAberration", "1"),
@@ -68,8 +73,10 @@ func TestHoltWintersAberration(t *testing.T) {
 					types.MakeMetricData("metric1", generateHwRange(0, points*step, step, 0), step, startTime),
 					types.MakeMetricData("metric2", generateHwRange(0, points*step, step, 10), step, startTime),
 				},
-				{"metric1", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, (((7*seconds)/step)+points)*step, step, 0), step, startTime-seconds)},
-				{"metric2", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric2", generateHwRange(0, (((7*seconds)/step)+points)*step, step, 10), step, startTime-seconds)},
+				{"metric*", startTime - seconds, startTime + step*points}: {
+					types.MakeMetricData("metric1", generateHwRange(0, ((seconds/step)+points)*step, step, 0), step, startTime-seconds),
+					types.MakeMetricData("metric2", generateHwRange(0, ((seconds/step)+points)*step, step, 10), step, startTime-seconds),
+				},
 			},
 			Want: []*types.MetricData{
 				types.MakeMetricData("holtWintersAberration(metric1)", []float64{-4.106587168490873, -2.8357974803355406, -1.5645896296885762, -0.4213549577359168, 0, 0, 0, 0.5073914761326588, 2.4432248533746543, 4.186719764193769}, step, startTime).SetTag("holtWintersAberration", "1"),

--- a/expr/functions/holtWintersForecast/function.go
+++ b/expr/functions/holtWintersForecast/function.go
@@ -31,6 +31,7 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 func (f *holtWintersForecast) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 1, 1, holtwinters.DefaultBootstrapInterval)
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -726,6 +726,58 @@ func TestMetrics(t *testing.T) {
 			},
 		},
 		{
+			"holtWintersAberration(metric1)",
+			&expr{
+				target: "holtWintersAberration",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+				},
+				argString: "metric1",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410346740,
+					Until:  1410346865,
+				},
+				{
+					Metric: "metric1",
+					From:   1409741940,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
+			"holtWintersAberration(metric1,3,'6d')",
+			&expr{
+				target: "holtWintersAberration",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "3", etype: EtConst},
+					{valStr: "6d", etype: EtString},
+				},
+				argString: "metric1, 3, '6d'",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1410346740,
+					Until:  1410346865,
+				},
+				{
+					Metric: "metric1",
+					From:   1409828340,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
 			"holtWintersConfidenceBands(metric1)",
 			&expr{
 				target: "holtWintersConfidenceBands",


### PR DESCRIPTION
This PR fixes some bugs in the holtWintersAberration function. The holtWintersAberration function requires access to both  the series fetched with the original from/until values, as well as data fetched with the adjusted start time (which is performed in pkg/parser/parser.go, in the Metrics() function). This is because this function compares values in the series corresponding to the original from/until values with those produced by the call to holtWintersConfidenceBands, which requires the series corresponding to the adjusted start time. This PR adds processing in the Metrics() function to add additional requests in the listof MetricRequests which use the start time adjusted with the bootstrapInterval. Then, in the holtWintersAberration function, the series associated with the time range with the adjusted start time is parsed via GetSeriesArg, and passed into the holtWintersConfidenceBands helper function. The result that the holtWintersConfidenceBands helper function returns is used for comparing against the series with the original from/until time in order to generate the final results of the query.

See the [holtWintersAberration function documentation](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.holtWintersAberration) and the [implementation in Graphite-web](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L4205) for details.