### PR TITLE
Add testing for holtWintersForecast function

### DIFF
--- a/expr/functions/holtWintersAberration/function.go
+++ b/expr/functions/holtWintersAberration/function.go
@@ -77,6 +77,7 @@ func (f *holtWintersAberration) Do(ctx context.Context, e parser.Expr, from, unt
 		}
 
 		lowerBand, upperBand := holtwinters.HoltWintersConfidenceBands(adjustedStartSeries[arg.Name].Values, stepTime, delta, bootstrapInterval, seasonality)
+
 		for i, v := range arg.Values {
 			if math.IsNaN(v) {
 				aberration = append(aberration, 0)

--- a/expr/functions/holtWintersForecast/function.go
+++ b/expr/functions/holtWintersForecast/function.go
@@ -31,7 +31,6 @@ func New(configFile string) []interfaces.FunctionMetadata {
 
 func (f *holtWintersForecast) Do(ctx context.Context, e parser.Expr, from, until int64, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 1, 1, holtwinters.DefaultBootstrapInterval)
-
 	if err != nil {
 		return nil, err
 	}

--- a/expr/functions/holtWintersForecast/function_test.go
+++ b/expr/functions/holtWintersForecast/function_test.go
@@ -1,0 +1,81 @@
+package holtWintersForecast
+
+import (
+	"testing"
+
+	"github.com/go-graphite/carbonapi/expr/helper"
+	"github.com/go-graphite/carbonapi/expr/metadata"
+	"github.com/go-graphite/carbonapi/expr/types"
+	"github.com/go-graphite/carbonapi/pkg/parser"
+	th "github.com/go-graphite/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestHoltWintersForecast(t *testing.T) {
+	var startTime int64 = 2678400
+	var step int64 = 600
+	var points int64 = 10
+	var seconds int64 = 86400
+
+	tests := []th.EvalTestItemWithRange{
+		{
+			Target: "holtWintersForecast(metric1)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", startTime - 7*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((7*seconds/step)+points)*step, step), step, startTime-7*seconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersForecast(metric1)", []float64{4.354532587468384, 5.233762480879125, 5.470443699760628, 5.400062907182546, 4.654782553991797, 4.85560658189784, 3.639077513586465, 4.192121821282148, 4.072238207117917, 4.754208902522321}, step, startTime).SetTag("holtWintersForecast", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+		{
+			Target: "holtWintersForecast(metric1,'6d')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", startTime - 6*seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((6*seconds/step)+points)*step, step), step, startTime-6*seconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersForecast(metric1)", []float64{3.756495938587323, 4.246729557688366, 4.0724537420914375, 4.707653738003789, 4.526243518254055, 5.324901822037504, 5.491471359733914, 5.360475158485411, 4.56317918291436, 4.719755423132087}, step, startTime).SetTag("holtWintersForecast", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+		{
+			Target: "holtWintersForecast(metric1,'1d','2d')",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((seconds/step)+points)*step, step), step, startTime-seconds)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("holtWintersForecast(metric1)", []float64{4.177645280818123, 4.258426771668244, 4.422358164063269, 4.662291902886368, 4.97168396144979, 5.344543965122753, 5.7753893169662724, 5.255703017827451, 4.881596120398131, 4.639466734477735}, step, startTime).SetTag("holtWintersForecast", "1"),
+			},
+			From:  startTime,
+			Until: startTime + step*points,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
+		})
+	}
+}
+
+func generateHwRange(x, y, jump int64) []float64 {
+	var valuesList []float64
+	for x < y {
+		val := float64((x / jump) % 10)
+		valuesList = append(valuesList, val)
+		x += jump
+	}
+	return valuesList
+}

--- a/expr/functions/holtWintersForecast/function_test.go
+++ b/expr/functions/holtWintersForecast/function_test.go
@@ -55,7 +55,7 @@ func TestHoltWintersForecast(t *testing.T) {
 				{"metric1", startTime - seconds, startTime + step*points}: {types.MakeMetricData("metric1", generateHwRange(0, ((seconds/step)+points)*step, step), step, startTime-seconds)},
 			},
 			Want: []*types.MetricData{
-				types.MakeMetricData("holtWintersForecast(metric1)", []float64{4.177645280818123, 4.258426771668244, 4.422358164063269, 4.662291902886368, 4.97168396144979, 5.344543965122753, 5.7753893169662724, 5.255703017827451, 4.881596120398131, 4.639466734477735}, step, startTime).SetTag("holtWintersForecast", "1"),
+				types.MakeMetricData("holtWintersForecast(metric1)", []float64{4.177645280818122, 4.168426771668243, 4.260421164063269, 4.443824969811369, 4.709783056245225, 5.0502969099660096, 5.458141774396228, 4.923291802762386, 4.540553676160961, 4.2952001684330225}, step, startTime).SetTag("holtWintersForecast", "1"),
 			},
 			From:  startTime,
 			Until: startTime + step*points,

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -197,7 +197,16 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 			}
 
 			return r2
-		case "holtWintersForecast", "holtWintersConfidenceBands", "holtWintersConfidenceArea":
+		case "holtWintersForecast":
+			bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 1, 1, holtwinters.DefaultBootstrapInterval)
+			if err != nil {
+				return nil
+			}
+
+			for i := range r {
+				r[i].From -= bootstrapInterval
+			}
+		case "holtWintersConfidenceBands", "holtWintersConfidenceArea":
 			bootstrapInterval, err := e.GetIntervalNamedOrPosArgDefault("bootstrapInterval", 2, 1, holtwinters.DefaultBootstrapInterval)
 			if err != nil {
 				return nil

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -785,7 +785,7 @@ func TestMetrics(t *testing.T) {
 				args: []*expr{
 					{target: "metric1"},
 				},
-				argString: "metric1, 4, '1d'",
+				argString: "metric1",
 			},
 			1410346740,
 			1410346865,
@@ -839,6 +839,26 @@ func TestMetrics(t *testing.T) {
 				{
 					Metric: "metric1",
 					From:   1410087540,
+					Until:  1410346865,
+				},
+			},
+		},
+		{
+			"holtWintersForecast(metric1,'1d')",
+			&expr{
+				target: "holtWintersConfidenceBands",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+				},
+				argString: "metric1",
+			},
+			1410346740,
+			1410346865,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   1409741940,
 					Until:  1410346865,
 				},
 			},


### PR DESCRIPTION
This PR adds tests for the holtWintersForecast function. Previously, not tests had been added. It also updates pkg/parser/parser.go's handling of holtWintersForecast, as it does not have the same parameter count as the other holtWinters* functions, so the parsing of the bootstrapInterval function is in a different position in the positional args list.