### PR TITLE
Various fixes for `exponentialMovingAverage`

### DIFF
--- a/expr/functions/exponentialMovingAverage/function.go
+++ b/expr/functions/exponentialMovingAverage/function.go
@@ -55,7 +55,7 @@ func (f *exponentialMovingAverage) Do(ctx context.Context, e parser.Expr, from, 
 		}
 
 		// When the window is an integer, we check the fetched data to get the
-		// step, and use it to calculate the preview window, to the refetch the
+		// step, and use it to calculate the preview window, to then refetch the
 		// data. The already fetched values are discarded.
 		refetch = true
 		var maxStep int64

--- a/expr/functions/exponentialMovingAverage/function.go
+++ b/expr/functions/exponentialMovingAverage/function.go
@@ -82,13 +82,8 @@ func (f *exponentialMovingAverage) Do(ctx context.Context, e parser.Expr, from, 
 		constant = float64(2 / (float64(previewSeconds) + 1))
 
 	default:
-		err = parser.ErrBadType
+		return nil, parser.ErrBadType
 	}
-	if err != nil {
-		return nil, err
-	}
-
-	var results []*types.MetricData
 
 	if previewSeconds < 1 {
 		return nil, fmt.Errorf("invalid window size %s", e.Arg(1).StringValue())
@@ -102,6 +97,7 @@ func (f *exponentialMovingAverage) Do(ctx context.Context, e parser.Expr, from, 
 		return nil, err
 	}
 
+	var results []*types.MetricData
 	for _, a := range previewList {
 		r := a.CopyLink()
 		r.Name = e.Target() + "(" + a.Name + "," + argstr + ")"
@@ -110,7 +106,7 @@ func (f *exponentialMovingAverage) Do(ctx context.Context, e parser.Expr, from, 
 			windowPoints = previewSeconds / int(a.StepTime)
 		}
 
-		var vals []float64
+		vals := make([]float64, 0, len(a.Values)/windowPoints+1)
 
 		if windowPoints > len(a.Values) {
 			mean := consolidations.AggMean(a.Values)

--- a/expr/functions/exponentialMovingAverage/function_test.go
+++ b/expr/functions/exponentialMovingAverage/function_test.go
@@ -30,7 +30,6 @@ func TestExponentialMovingAverage(t *testing.T) {
 		{
 			Target: "exponentialMovingAverage(metric1,'30s')",
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"metric1", from, from + step*6}:      {types.MakeMetricData("metric1", []float64{8, 12, 14, 16, 18, 20}, step, from)},
 				{"metric1", from - 30, from + step*6}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, step, from-30)},
 			},
 			Want: []*types.MetricData{
@@ -42,6 +41,8 @@ func TestExponentialMovingAverage(t *testing.T) {
 		{
 			Target: "exponentialMovingAverage(empty,3)",
 			M: map[parser.MetricRequest][]*types.MetricData{
+				// When the window is an integer, the original from-until range is used to get the step.
+				// That's why two requests are made.
 				{"empty", from, from + step*4}:          {},
 				{"empty", from - step*3, from + step*4}: {},
 			},
@@ -80,7 +81,6 @@ func TestExponentialMovingAverage(t *testing.T) {
 		{
 			Target: `exponentialMovingAverage(collectd.test-db0.load.value,"-30s")`,
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{"collectd.test-db0.load.value", from, from + 30}:      {types.MakeMetricData("collectd.test-db0.load.value", rangeFloats(-60, 60, 1), 1, from)},
 				{"collectd.test-db0.load.value", from - 30, from + 30}: {types.MakeMetricData("collectd.test-db0.load.value", rangeFloats(0, 60, 1), 1, from-30)},
 			},
 			Want: []*types.MetricData{

--- a/expr/functions/exponentialMovingAverage/function_test.go
+++ b/expr/functions/exponentialMovingAverage/function_test.go
@@ -34,7 +34,7 @@ func TestExponentialMovingAverage(t *testing.T) {
 				{"metric1", from - 30, from + step*6}: {types.MakeMetricData("metric1", []float64{2, 4, 6, 8, 12, 14, 16, 18, 20}, step, from-30)},
 			},
 			Want: []*types.MetricData{
-				types.MakeMetricData("exponentialMovingAverage(metric1,\"30s\")", []float64{4, 6, 9, 11.5, 13.75, 15.875, 17.9375}, step, from).SetTag("exponentialMovingAverage", `"30s"`),
+				types.MakeMetricData("exponentialMovingAverage(metric1,\"30s\")", []float64{4, 4.258065, 4.757544, 5.353832, 6.040681, 6.81225, 7.663073}, step, from).SetTag("exponentialMovingAverage", `"30s"`),
 			},
 			From:  from,
 			Until: from + step*6,
@@ -75,6 +75,21 @@ func TestExponentialMovingAverage(t *testing.T) {
 			},
 			From:  from,
 			Until: from + 10,
+		},
+		// copied from Graphite Web
+		{
+			Target: `exponentialMovingAverage(collectd.test-db0.load.value,"-30s")`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"collectd.test-db0.load.value", from, from + 30}:      {types.MakeMetricData("collectd.test-db0.load.value", rangeFloats(-60, 60, 1), 1, from)},
+				{"collectd.test-db0.load.value", from - 30, from + 30}: {types.MakeMetricData("collectd.test-db0.load.value", rangeFloats(0, 60, 1), 1, from-30)},
+			},
+			Want: []*types.MetricData{
+				types.MakeMetricData("exponentialMovingAverage(collectd.test-db0.load.value,\"-30s\")", []float64{
+					14.5, 15.5, 16.5, 17.5, 18.5, 19.5, 20.5, 21.5, 22.5, 23.5, 24.5, 25.5, 26.5, 27.5, 28.5, 29.5, 30.5, 31.5, 32.5, 33.5, 34.5, 35.5, 36.5, 37.5, 38.5, 39.5, 40.5, 41.5, 42.5, 43.5, 44.5,
+				}, 1, from).SetTag("exponentialMovingAverage", `"-30s"`),
+			},
+			From:  from,
+			Until: from + 30,
 		},
 	}
 


### PR DESCRIPTION
Multiple fixes for `exponentialMovingAverage`:

- Adjust the `from` to take the preview window of the series when getting the argument. This bug was previously producing empty results in some scenarios.
- Correctly calculate the `previewSeconds` when the window size is an integer, and refetch the data as necessary
- Correctly calculate the `constant` used for the window, which is calculated differently depending on whether the window is an integer or a string interval. See [graphite web](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L1408-L1411)
- Default to zero when the preview average (of the window) is NaN. See [Graphite Web](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L1432).
- Set Start Time [like Graphite Web does](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L1430).