### PR TITLE
Fix for moving* functions with length of data points smaller than the windowPoints

### DIFF
--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -196,7 +196,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			continue
 		}
 
-		size := len(a.Values) - int(windowPoints)
+		size := len(a.Values) - windowPoints
 		if size < 0 {
 			size = 0
 		}

--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -105,7 +105,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 		}
 		preview = maxStep * int64(n)
 		adjustedStart -= maxStep * int64(n)
-		windowPoints = int(preview)
+		windowPoints = n
 		refetch = true
 	case parser.EtString:
 		var n32 int32
@@ -195,7 +195,12 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int64, value
 			result[j] = r
 			continue
 		}
-		r.Values = make([]float64, len(a.Values)-int(windowPoints))
+
+		size := len(a.Values) - int(windowPoints)
+		if size < 0 {
+			size = 0
+		}
+		r.Values = make([]float64, size)
 		r.StartTime = a.StartTime + preview
 		r.StopTime = r.StartTime + int64(len(r.Values))*r.StepTime
 

--- a/expr/functions/moving/function_test.go
+++ b/expr/functions/moving/function_test.go
@@ -238,6 +238,17 @@ func TestMoving(t *testing.T) {
 			From:  610,
 			Until: 710,
 		},
+		{
+			Target: "movingAverage(metric1,10)",
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 610, 700}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 30, 610)}, // step > windowSize
+				{"metric1", 310, 700}: {types.MakeMetricData("metric1", []float64{1, 2, 3}, 30, 310)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData(`movingAverage(metric1,10)`,
+				[]float64{}, 30, 610).SetTag("movingAverage", "10").SetNameTag(`movingAverage(metric1,10)`)},
+			From:  610,
+			Until: 700,
+		},
 	}
 
 	for n, tt := range tests {


### PR DESCRIPTION
This PR fixes a bug in the moving* functions when the length of the values is less than the number of windowPoints. It also addresses a bug with the setting of windowPoints when an integer windowSize is used in the query.