### PR TITLE
`currentAbove` and similar to do '>' and not '>='

### DIFF
--- a/expr/functions/below/function.go
+++ b/expr/functions/below/function.go
@@ -46,7 +46,6 @@ func (f *below) Do(ctx context.Context, e parser.Expr, from, until int64, values
 	}
 
 	isAbove := strings.HasSuffix(e.Target(), "Above")
-	isInclusive := true
 	var compute func([]float64) float64
 	switch {
 	case strings.HasPrefix(e.Target(), "average"):
@@ -55,28 +54,18 @@ func (f *below) Do(ctx context.Context, e parser.Expr, from, until int64, values
 		compute = consolidations.CurrentValue
 	case strings.HasPrefix(e.Target(), "maximum"):
 		compute = consolidations.MaxValue
-		isInclusive = false
 	case strings.HasPrefix(e.Target(), "minimum"):
 		compute = consolidations.MinValue
-		isInclusive = false
 	}
 	results := make([]*types.MetricData, 0, len(args))
 	for _, a := range args {
 		value := compute(a.Values)
 		if isAbove {
-			if isInclusive {
-				if value >= n {
-					results = append(results, a)
-				}
-			} else {
-				if value > n {
-					results = append(results, a)
-				}
-			}
-		} else {
-			if value <= n {
+			if value > n {
 				results = append(results, a)
 			}
+		} else if value <= n {
+			results = append(results, a)
 		}
 	}
 

--- a/expr/functions/below/function_test.go
+++ b/expr/functions/below/function_test.go
@@ -33,6 +33,7 @@ func TestBelow(t *testing.T) {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
 					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
 					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 7}, 1, now32),
 				},
 			},
 			[]*types.MetricData{types.MakeMetricData("metricB",
@@ -55,13 +56,12 @@ func TestBelow(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {
 					types.MakeMetricData("metricA", []float64{0, 0, 0, 0, 0, 0}, 1, now32),
-					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
-					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
+					types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32), // avg=5.5
+					types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32), // avg=5
 				},
 			},
 			[]*types.MetricData{
 				types.MakeMetricData("metricB", []float64{3, 4, 5, 6, 7, 8}, 1, now32),
-				types.MakeMetricData("metricC", []float64{4, 4, 5, 5, 6, 6}, 1, now32),
 			},
 		},
 		{


### PR DESCRIPTION
The `xAbove` functions should not include series that match by `=`. I.e., the filtering should be by `>` and not by `>=`.

This is consistent with Graphite Web. See `currentAbove` ([link](https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/render/functions.py#L3308)) and all similar `xAbove` functions.


I don't know why the `isInclusive` bool was there originally. I checked GraphiteWeb and it never does that. I also looked at the original carbonapi PR introducing this function, and I see no specific references to this.