### PR TITLE
Add support for alignDST parameter for timeShift function

### DIFF
--- a/cmd/carbonapi/config/init.go
+++ b/cmd/carbonapi/config/init.go
@@ -411,6 +411,7 @@ func SetUpViper(logger *zap.Logger, configPath *string, viperPrefix string) {
 	}
 
 	fconfig.Config.ExtractTagsFromArgs = Config.ExtractTagsFromArgs
+	fconfig.Config.DefaultTimeZone = Config.DefaultTimeZone
 }
 
 func SetUpConfigUpstreams(logger *zap.Logger) {

--- a/cmd/mockbackend/testcases/pr529/pr529.yaml
+++ b/cmd/mockbackend/testcases/pr529/pr529.yaml
@@ -17,7 +17,7 @@ test:
                   expectedResults:
                           - metrics:
                                   - target: "maxSeries(metric,asPercent(timeShift(metric,'1s', false),metric))"
-                                    datapoints: [[1,3],[100,4],[100,5],[100,6],[100,7],["null", 8]]
+                                    datapoints: [[100,3],[100,4],[100,5],[100,6],[100,7]]
 listeners:
         - address: ":9070"
           expressions:
@@ -28,3 +28,4 @@ listeners:
                                values: [1.0, 1.0, 1.0, 1.0, 1.0]
                                step: 1
                                startTime: 3
+

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -2,7 +2,6 @@ package expr
 
 import (
 	"context"
-
 	"github.com/ansel1/merry"
 	pb "github.com/go-graphite/protocol/carbonapi_v3_pb"
 
@@ -29,7 +28,7 @@ func (eval evaluator) Fetch(ctx context.Context, exprs []parser.Expr, from, unti
 
 	haveFallbackSeries := false
 	for _, exp := range exprs {
-		for _, m := range exp.Metrics(from, until) {
+		for _, m := range exp.Metrics(from, until, config.Config.DefaultTimeZone) {
 			fetchRequest := pb.FetchRequest{
 				Name:           m.Metric,
 				PathExpression: m.Metric,

--- a/expr/functions/config/config.go
+++ b/expr/functions/config/config.go
@@ -1,5 +1,8 @@
 package config
 
+import "time"
+
 var Config = struct {
 	ExtractTagsFromArgs bool
+	DefaultTimeZone     *time.Location
 }{}

--- a/expr/functions/timeShift/function.go
+++ b/expr/functions/timeShift/function.go
@@ -3,12 +3,10 @@ package timeShift
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"time"
-
 	"github.com/lomik/zapwriter"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+	"strconv"
 
 	fconfig "github.com/go-graphite/carbonapi/expr/functions/config"
 	"github.com/go-graphite/carbonapi/expr/helper"
@@ -132,22 +130,15 @@ func (f *timeShift) Do(ctx context.Context, e parser.Expr, from, until int64, va
 		} else {
 			r.StopTime = a.StopTime - a.StartTime + series.StartTime
 		}
-
+		length := int((r.StopTime - r.StartTime) / r.StepTime)
+		if length >= 0 && length < len(r.Values) {
+			r.Values = r.Values[:length]
+		}
 		r.Tags["timeshift"] = fmt.Sprintf("%d", offs)
 		results[n] = r
-
 	}
 
 	return results, nil
-}
-
-func localTimeIsDST(t time.Time) bool {
-	var tz = fconfig.Config.DefaultTimeZone
-	if z, err := time.LoadLocation(tz.String()); err != nil {
-		tz = z
-	}
-	localTime := t.In(tz)
-	return localTime.IsDST()
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/functions/timeShift/function_test.go
+++ b/expr/functions/timeShift/function_test.go
@@ -2,7 +2,9 @@ package timeShift
 
 import (
 	"testing"
+	"time"
 
+	fconfig "github.com/go-graphite/carbonapi/expr/functions/config"
 	"github.com/go-graphite/carbonapi/expr/helper"
 	"github.com/go-graphite/carbonapi/expr/metadata"
 	"github.com/go-graphite/carbonapi/expr/types"
@@ -26,11 +28,33 @@ func TestTimeShift(t *testing.T) {
 	tests := []th.EvalTestItemWithRange{
 		// TODO(civil): Do not pass `true` resetEnd parameter in 0.15
 		{
+			Target: `timeShift(metric1, "-10minutes")`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 600, Until: 1200}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 60, 600)},
+				{Metric: "metric1", From: 0, Until: 600}:    {types.MakeMetricData("metric1", []float64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 60, 0)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-600')",
+				[]float64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 60, 600).SetTag("timeshift", "-600")},
+			From:  600,
+			Until: 1200,
+		},
+		{
+			Target: `timeShift(metric1, "-10minutes")`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 600, Until: 1200}: {},
+				{Metric: "metric1", From: 0, Until: 600}:    {types.MakeMetricData("metric1", []float64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 60, 0)},
+			},
+			Want:  []*types.MetricData{},
+			From:  600,
+			Until: 1200,
+		},
+		{
 			Target: `timeShift(metric1, "0s", true)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: startTime, Until: startTime + 6}: {types.MakeMetricData("metric1", []float64{5, 4, 3, 2, 1, 0}, 1, startTime)},
 				{Metric: "metric1", From: startTime, Until: startTime + 6}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5}, 1, startTime)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'0',true)",
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'0')",
 				[]float64{0, 1, 2, 3, 4, 5}, 1, startTime).SetTag("timeshift", "0")},
 			From:  startTime,
 			Until: startTime + 6,
@@ -38,9 +62,10 @@ func TestTimeShift(t *testing.T) {
 		{
 			Target: `timeShift(metric1, "1s", false)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: startTime, Until: startTime + 6}:     {types.MakeMetricData("metric1", []float64{5, 4, 3, 2, 1, 0}, 1, startTime)},
 				{Metric: "metric1", From: startTime - 1, Until: startTime + 5}: {types.MakeMetricData("metric1", []float64{-1, 0, 1, 2, 3, 4}, 1, startTime-1)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-1',false)",
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-1')",
 				[]float64{-1, 0, 1, 2, 3, 4}, 1, startTime).SetTag("timeshift", "-1")},
 			From:  startTime,
 			Until: startTime + 6,
@@ -48,9 +73,10 @@ func TestTimeShift(t *testing.T) {
 		{
 			Target: `timeShift(metric1, "1s", true)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: startTime, Until: startTime + 6}:     {types.MakeMetricData("metric1", []float64{3, 2, 1, 0, -1}, 1, startTime)},
 				{Metric: "metric1", From: startTime - 1, Until: startTime + 5}: {types.MakeMetricData("metric1", []float64{-1, 0, 1, 2, 3}, 1, startTime-1)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-1',true)",
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-1')",
 				[]float64{-1, 0, 1, 2, 3}, 1, startTime).SetTag("timeshift", "-1")},
 			From:  startTime,
 			Until: startTime + 6,
@@ -58,9 +84,10 @@ func TestTimeShift(t *testing.T) {
 		{
 			Target: `timeShift(metric1, "1h", false)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: startTime, Until: startTime + 6}:                 {types.MakeMetricData("metric1", []float64{4, 3, 2, 1, 0, -1}, 1, startTime)},
 				{Metric: "metric1", From: startTime - 60*60, Until: startTime - 60*60 + 6}: {types.MakeMetricData("metric1", []float64{-1, 0, 1, 2, 3, 4}, 1, startTime-60*60)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-3600',false)",
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-3600')",
 				[]float64{-1, 0, 1, 2, 3, 4}, 1, startTime).SetTag("timeshift", "-3600")},
 			From:  startTime,
 			Until: startTime + 6,
@@ -68,9 +95,10 @@ func TestTimeShift(t *testing.T) {
 		{
 			Target: `timeShift(metric1, "1h", true)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: startTime, Until: startTime + 6}:                 {types.MakeMetricData("metric1", []float64{4, 3, 2, 1, 0, -1}, 1, startTime)},
 				{Metric: "metric1", From: startTime - 60*60, Until: startTime - 60*60 + 6}: {types.MakeMetricData("metric1", []float64{-1, 0, 1, 2, 3, 4}, 1, startTime-60*60)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-3600',true)",
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-3600')",
 				[]float64{-1, 0, 1, 2, 3, 4}, 1, startTime).SetTag("timeshift", "-3600")},
 			From:  startTime,
 			Until: startTime + 6,
@@ -78,9 +106,10 @@ func TestTimeShift(t *testing.T) {
 		{
 			Target: `timeShift(metric1, "1d", false)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: startTime, Until: startTime + 6}:                 {types.MakeMetricData("metric1", []float64{4, 3, 2, 1, 0, -1}, 1, startTime)},
 				{Metric: "metric1", From: startTime - 86400, Until: startTime - 86400 + 6}: {types.MakeMetricData("metric1", []float64{-1, 0, 1, 2, 3, 4}, 1, startTime-86400)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-86400',false)",
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-86400')",
 				[]float64{-1, 0, 1, 2, 3, 4}, 1, startTime).SetTag("timeshift", "-86400")},
 			From:  startTime,
 			Until: startTime + 6,
@@ -88,9 +117,10 @@ func TestTimeShift(t *testing.T) {
 		{
 			Target: `timeShift(metric1, "1d", true)`,
 			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: startTime, Until: startTime + 6}:                 {types.MakeMetricData("metric1", []float64{4, 3, 2, 1, 0, -1}, 1, startTime)},
 				{Metric: "metric1", From: startTime - 86400, Until: startTime - 86400 + 6}: {types.MakeMetricData("metric1", []float64{-1, 0, 1, 2, 3, 4}, 1, startTime-86400)},
 			},
-			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-86400',true)",
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-86400')",
 				[]float64{-1, 0, 1, 2, 3, 4}, 1, startTime).SetTag("timeshift", "-86400")},
 			From:  startTime,
 			Until: startTime + 6,
@@ -99,6 +129,42 @@ func TestTimeShift(t *testing.T) {
 
 	for _, tt := range tests {
 		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExprWithRange(t, &tt)
+		})
+	}
+}
+
+func TestTimeShift_AlignDST(t *testing.T) {
+	tests := []th.EvalTestItemWithRange{
+		{
+			Target: `timeShift(metric1, "-1d", false, true)`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 323869020, Until: 323872620}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 3600, 323869020)},
+				{Metric: "metric1", From: 323786220, Until: 323789820}: {types.MakeMetricData("metric1", []float64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 3600, 323786220)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-86400')",
+				[]float64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 3600, 323869020).SetTag("timeshift", "-86400")},
+			From:  323869020,
+			Until: 323872620,
+		},
+		{
+			Target: `timeShift(metric1, "-1h", false, true)`,
+			M: map[parser.MetricRequest][]*types.MetricData{
+				{Metric: "metric1", From: 323869020, Until: 323872620}: {types.MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 3600, 323869020)},
+				{Metric: "metric1", From: 323865420, Until: 323869020}: {types.MakeMetricData("metric1", []float64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 3600, 323865420)},
+			},
+			Want: []*types.MetricData{types.MakeMetricData("timeShift(metric1,'-3600')",
+				[]float64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 3600, 323869020).SetTag("timeshift", "-3600")},
+			From:  323869020,
+			Until: 323872620,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		loc, _ := time.LoadLocation("Europe/Berlin")
+		fconfig.Config.DefaultTimeZone = loc
 		t.Run(testName, func(t *testing.T) {
 			th.TestEvalExprWithRange(t, &tt)
 		})

--- a/expr/functions/timeShift/function_test.go
+++ b/expr/functions/timeShift/function_test.go
@@ -27,6 +27,7 @@ func TestTimeShift(t *testing.T) {
 
 	tests := []th.EvalTestItemWithRange{
 		// TODO(civil): Do not pass `true` resetEnd parameter in 0.15
+		// Note: some of these test cases are based off of timeShift tests in Graphite-web to ensure consistency
 		{
 			Target: `timeShift(metric1, "-10minutes")`,
 			M: map[parser.MetricRequest][]*types.MetricData{
@@ -41,7 +42,7 @@ func TestTimeShift(t *testing.T) {
 		{
 			Target: `timeShift(metric1, "-10minutes")`,
 			M: map[parser.MetricRequest][]*types.MetricData{
-				{Metric: "metric1", From: 600, Until: 1200}: {},
+				{Metric: "metric1", From: 600, Until: 1200}: {}, // Check handling of empty series
 				{Metric: "metric1", From: 0, Until: 600}:    {types.MakeMetricData("metric1", []float64{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 60, 0)},
 			},
 			Want:  []*types.MetricData{},

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // MetricRequest contains all necessary data to request a metric.
@@ -119,7 +120,7 @@ type Expr interface {
 	MutateRawArgs(args string) Expr
 
 	// Metrics returns list of metric requests
-	Metrics(from, until int64) []MetricRequest
+	Metrics(from, until int64, tz *time.Location) []MetricRequest
 
 	// GetIntervalArg returns interval typed argument.
 	GetIntervalArg(n int, defaultSign int) (int32, error)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -158,15 +158,6 @@ func (e *expr) Metrics(from, until int64) []MetricRequest {
 			if !referenceSeriesExpr.IsInterfaceNil() {
 				r = append(r, referenceSeriesExpr.Metrics(from, until)...)
 			}
-		case "timeShift":
-			offs, err := e.GetIntervalArg(1, -1)
-			if err != nil {
-				return nil
-			}
-			for i := range r {
-				r[i].From += int64(offs)
-				r[i].Until += int64(offs)
-			}
 		case "timeStack":
 			offs, err := e.GetIntervalArg(1, -1)
 			if err != nil {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -169,24 +169,17 @@ func (e *expr) Metrics(from, until int64, tz *time.Location) []MetricRequest {
 				return nil
 			}
 
-			newFrom := from + int64(offs)
-			newUntil := until + int64(offs)
-
-			if alignDST {
-				newFrom, newUntil, err = AlignDST(from, until, offs, tz)
-				if err != nil {
-					return nil
-				}
-			}
-
 			var r2 []MetricRequest
 			for i := range r {
-				// Append the original request
-				r2 = append(r2, MetricRequest{
-					Metric: r[i].Metric,
-					From:   r[i].From,
-					Until:  r[i].Until,
-				})
+				newFrom := r[i].From + int64(offs)
+				newUntil := r[i].Until + int64(offs)
+				if alignDST {
+					newFrom, newUntil, err = AlignDST(from, until, offs, tz)
+					if err != nil {
+						return nil
+					}
+				}
+
 				// Append a request with modified start and end time
 				r2 = append(r2, MetricRequest{
 					Metric: r[i].Metric,
@@ -195,7 +188,7 @@ func (e *expr) Metrics(from, until int64, tz *time.Location) []MetricRequest {
 				})
 			}
 
-			return r2
+			return append(r, r2...)
 		case "timeStack":
 			offs, err := e.GetIntervalArg(1, -1)
 			if err != nil {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -667,6 +668,7 @@ func TestMetrics(t *testing.T) {
 		from     int64
 		to       int64
 		expected []MetricRequest
+		tz       string
 	}{
 		{
 			"hitcount(metric1, '1h', true)",
@@ -689,6 +691,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"hitcount(metric1, '1h', alignToInterval=True)",
@@ -717,6 +720,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"hitcount(metric1, '1h')",
@@ -738,6 +742,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"hitcount(timeShift(metric1, '-1h'),'1h')",
@@ -764,10 +769,16 @@ func TestMetrics(t *testing.T) {
 			[]MetricRequest{
 				{
 					Metric: "metric1",
+					From:   1410343200,
+					Until:  1410346865,
+				},
+				{
+					Metric: "metric1",
 					From:   1410339600,
 					Until:  1410343265,
 				},
 			},
+			"UTC",
 		},
 		{
 			"holtWintersAberration(metric1)",
@@ -793,6 +804,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"holtWintersAberration(metric1,3,'6d')",
@@ -820,6 +832,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"holtWintersConfidenceBands(metric1)",
@@ -840,6 +853,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"holtWintersConfidenceBands(metric1, 4, '1d')",
@@ -862,6 +876,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"holtWintersConfidenceBands(metric1, 4, bootstrapInterval='3d')",
@@ -886,6 +901,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"holtWintersForecast(metric1,'1d')",
@@ -906,6 +922,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"smartSummarize(metric1, '1h', 'sum', 'seconds')",
@@ -929,6 +946,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"smartSummarize(metric1, '1h', 'sum', '1minutes')",
@@ -952,6 +970,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"smartSummarize(metric1, '1h', 'sum', 'hours')",
@@ -975,6 +994,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"smartSummarize(metric1, '1h', 'sum', 'days')",
@@ -998,6 +1018,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"smartSummarize(metric1, '1hours','sum','weeks5')",
@@ -1021,6 +1042,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"smartSummarize(metric1, '1hours','sum','months')",
@@ -1044,6 +1066,7 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
 		},
 		{
 			"smartSummarize(metric1, '1hours','sum','y')",
@@ -1067,12 +1090,70 @@ func TestMetrics(t *testing.T) {
 					Until:  1410346865,
 				},
 			},
+			"UTC",
+		},
+		{
+			"timeShift(metric1, '1h')",
+			&expr{
+				target: "timeShift",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1h", etype: EtString},
+				},
+				argString: "metric1, '1h'",
+			},
+			323869020,
+			323872620,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   323869020,
+					Until:  323872620,
+				},
+				{
+					Metric: "metric1",
+					From:   323865420,
+					Until:  323869020,
+				},
+			},
+			"Europe/Berlin",
+		},
+		{
+			"timeShift(metric1, '1d',true,true)",
+			&expr{
+				target: "timeShift",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric1"},
+					{valStr: "1d", etype: EtString},
+					{valStr: "true", etype: EtBool},
+					{valStr: "true", etype: EtBool},
+				},
+				argString: "metric1, '1d', true, true",
+			},
+			323869020,
+			323872620,
+			[]MetricRequest{
+				{
+					Metric: "metric1",
+					From:   323869020,
+					Until:  323872620,
+				},
+				{
+					Metric: "metric1",
+					From:   323786220,
+					Until:  323789820,
+				},
+			},
+			"Europe/Berlin",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.s, func(t *testing.T) {
 
-			r := tt.e.Metrics(tt.from, tt.to)
+			loc, _ := time.LoadLocation(tt.tz)
+			r := tt.e.Metrics(tt.from, tt.to, loc)
 			assert.Equal(t, tt.expected, r)
 		})
 	}


### PR DESCRIPTION
This PR adds support for the optional alignDST parameter for the timeshift function. [This parameter](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.timeShift) will compensate for misalignment that can occur when shifting a time period with DST to a time period without it, or vice versa. This parameter was previously unsupported, so results could be inaccurate by +/- 1 hour depending on the time period shift that is occurring. 

See the [Graphite web implementation](https://github.com/graphite-project/graphite-web/blob/dca59dc72ae28ffdae659232c10c60aa598536eb/webapp/graphite/render/functions.py#L4526) of the alignDST parameter.